### PR TITLE
Replaced references to pyrap -> casacore

### DIFF
--- a/casacore/fitting/__init__.py
+++ b/casacore/fitting/__init__.py
@@ -41,7 +41,7 @@ The fitting module
 
 For most uses we will create a single fitting object to work with::
 
-    from pyrap.fitting import fitserver
+    from casacore.fitting import fitserver
     dfit = fitserver()
 
 
@@ -56,7 +56,7 @@ indices to loop over. In both cases the parameters of the tool can be given
 in the constructor (fitter method), or in a separate init method (see next
 example of the highest level use)::
 
-    from pyrap.fitting import fitserver
+    from casacore.fitting import fitserver
     myfit = fitserver()		# general fitting object created
     				# (needs initializing before it can be used)
     cpid = myfit.fitter(ftype='complex') # and another (sub-)fitter

--- a/casacore/fitting/fitting.py
+++ b/casacore/fitting/fitting.py
@@ -1,5 +1,5 @@
 from _fitting import fitting
-from pyrap.functionals import *
+from casacore.functionals import *
 import numpy as NUM
 
 class fitserver(object):
@@ -10,7 +10,7 @@ class fitserver(object):
     conjugate (complex with both the unknown and its conjugate in the
     condition equations), separable complex, asreal complex with the real and
     imaginary part seen as independent unknowns. All solutions need a model
-    (specified as a :mod:`pyrap.functionals`. All solutions are done using an
+    (specified as a :mod:`casacore.functionals`. All solutions are done using an
     SVD type method. A collinearity factor can be specified, which is in
     essence the sine squared of the minimum angle between two normal equation
     columns that are still to be considered independent. For automatic

--- a/casacore/functionals/__init__.py
+++ b/casacore/functionals/__init__.py
@@ -35,19 +35,19 @@ parameters, and for the automatic calculation of the derivatives with respect
 to the parameters.
 
 The created functionals can be used for fitiing as provided by 
-:mod:`pyrap.fitting`.
+:mod:`casacore.fitting`.
 
 A functional has a mask associated with it, to indicate if certain parameters 
 have to be solved for. See masks for details.
 
-To access the functionals module ``import pyrap.functionals``.
+To access the functionals module ``import casacore.functionals``.
 
 Functionals are created in a variety of ways, in general by specifying the 
 name of the functional, together with some necessary information like e.g. 
 the order of a polynomial, or the code needed to compile your privately d
 efined function. Parameters can be set at creation time or later::
 
-    >>> from pyrap.functionals import functional, gaussian1d
+    >>> from casacore.functionals import functional, gaussian1d
     >>> a = gaussian1d()	    # creates a 1D Gaussian, default arguments
     >>> b = functional('gaussian1') # creates the same one
     >>> print a.f(1)                # the value at x=1
@@ -59,7 +59,7 @@ efined function. Parameters can be set at creation time or later::
 
 In some cases an order can be specified as well (e.g. for polynomials)::
 
-    >>> from pyrap.functionals import functional, poly
+    >>> from casacore.functionals import functional, poly
     >>> a = poly(3)               # creates a 3rd order polynomial
     >>> print a
     {'ndim': 1, 'masks': array([ True,  True,  True,  True], dtype=bool),
@@ -70,7 +70,7 @@ create a functional from a compiled string specifying an arbitrary function.
 For example, let us make our own polynomial ``1 + 2*x + 3*x2`` and evaluate it 
 at a few abcissa locations::
 
-    >>> from pyrap.functionals import compiled
+    >>> from casacore.functionals import compiled
     >>> a = compiled('p0 + p1*x + p2*x*x', [1,2,3])   # Define
     >>> a([0,10,20])                                  # Evaluate at x=[0,10,20]
     [1.0, 321.0, 1241.0]

--- a/casacore/functionals/functional.py
+++ b/casacore/functionals/functional.py
@@ -292,7 +292,7 @@ class compiled(functional):
 
     Examples::
 
-        >>> from pyrap.functionals import compiled
+        >>> from casacore.functionals import compiled
         >>> import math
         >>> a = compiled('sin(pi(0.5) ) +pi');  # an example
         >>> print a(0)

--- a/casacore/images/image.py
+++ b/casacore/images/image.py
@@ -33,7 +33,7 @@ try:
 except ImportError:
     import numpy.core.ma as nma
 
-from pyrap.images.coordinates import coordinatesystem
+from casacore.images.coordinates import coordinatesystem
 
 class image(Image):
     """The Python interface to casacore images.
@@ -147,10 +147,10 @@ class image(Image):
                             imgs += [img]
                         try:
                             # Substitute possible $ arguments
-                            import pyrap.util
-                            imagename = pyrap.util.substitute(imagename, [(image, '', imgs)], locals=pyrap.util.getlocals(3))
+                            import casacore.util
+                            imagename = casacore.util.substitute(imagename, [(image, '', imgs)], locals=casacore.util.getlocals(3))
                         except:
-                            print "Probably could not import pyrap.util"
+                            print "Probably could not import casacore.util"
                             pass
                         Image.__init__ (self, imagename, maskname, imgs)
                     else:

--- a/casacore/measures/__init__.py
+++ b/casacore/measures/__init__.py
@@ -27,7 +27,7 @@
 __all__ = ['is_measure', 'measures']
 
 import os
-import pyrap.quanta as dq
+import casacore.quanta as dq
 from  _measures import measures as _measures
 
 if os.environ.has_key("MEASURESDATA"):
@@ -75,7 +75,7 @@ class measures(_measures):
 
     Typical usage::
 
-        from pyrap.measures import measures
+        from casacore.measures import measures
         dm = measures() # create measures server instance
         dirmeas = dm.direction()
 
@@ -131,9 +131,9 @@ class measures(_measures):
 
         :param v0, v1: Direction quantity values should be
                        longitude (angle) and latitude (angle) or strings
-                       parsable by :func:`~pyrap.quanta.quantity`.
+                       parsable by :func:`~casacore.quanta.quantity`.
                        None are needed for planets: the frame epoch defines
-                       coordinates. See :func:`~pyrap.quanta.quantity` for
+                       coordinates. See :func:`~casacore.quanta.quantity` for
                        possible angle formats.
         :param off: an optional offset measure of same type
 
@@ -164,7 +164,7 @@ class measures(_measures):
 
         The position quantity values should be either longitude (angle),
         latitude(angle) and height(length); or x,y,z (length). See
-        :func:`~pyrap.quanta.quantity` for possible angle formats.
+        :func:`~casacore.quanta.quantity` for possible angle formats.
 
         :param rf: reference code string; Allowable reference
                    codes are: *WGS84* *ITRF* (World Geodetic System and
@@ -275,7 +275,7 @@ class measures(_measures):
 
         Example::
 
-            >>> from pyrap import quanta
+            >>> from casacore import quanta
             >>> dm.doppler('radio', 0.4)
             >>> dm.doppler('radio', '0.4')
             >>> dm.doppler('RADIO', quanta.constants['c']*0.4))
@@ -390,7 +390,7 @@ class measures(_measures):
         International Geomagnetic Reference Field). The earthmagnetic quantity
         values should be either longitude (angle), latitude(angle) and
         length(field strength); or x,y,z (field).
-        See :func:`~pyrap.quanta.quantity` for possible angle formats.
+        See :func:`~casacore.quanta.quantity` for possible angle formats.
 
         :param rf: reference code string; Allowable reference
                    codes are: *IGRF*
@@ -565,7 +565,7 @@ class measures(_measures):
 
         Example::
 
-            >>> from pyrap.quanta import quantity
+            >>> from casacore.quanta import quantity
             >>> x = quantity([10,50],'m')
             >>> y = quantity([20,100],'m')
             >>> z = quantity([30,150],'m')

--- a/casacore/tables/table.py
+++ b/casacore/tables/table.py
@@ -87,11 +87,11 @@ def taql (command, style='Python', tables=[], globals={}, locals={}):
     for tab in tables:
         tabs += [tab]
     try:
-        import pyrap.util
+        import casacore.util
         if len(locals) == 0:
             # local variables in caller are 3 levels up from getlocals
-            locals = pyrap.util.getlocals(3)
-        cmd = pyrap.util.substitute(cmd, [(table, '', tabs)], globals, locals)
+            locals = casacore.util.getlocals(3)
+        cmd = casacore.util.substitute(cmd, [(table, '', tabs)], globals, locals)
     except:
         pass
     if style:
@@ -1127,14 +1127,14 @@ class table(Table):
         tdesc = desc
         # Create a tabdesc if only a coldesc is given.
         if desc.has_key('name'):
-            import pyrap.tables.tableutil
+            import casacore.tables.tableutil
             if len(desc)==2 and desc.has_key('desc'):
                 # Given as output from makecoldesc
-                tdesc = pyrap.tables.tableutil.maketabdesc(desc);
+                tdesc = casacore.tables.tableutil.maketabdesc(desc);
             elif desc.has_key('valueType'):
             # Given as output of getcoldesc (with a name field added)
-                cd = pyrap.tables.tableutil.makecoldesc (desc['name'], desc)
-                tdesc = pyrap.tables.tableutil.maketabdesc(cd)
+                cd = casacore.tables.tableutil.makecoldesc (desc['name'], desc)
+                tdesc = casacore.tables.tableutil.maketabdesc(cd)
         self._addcols (tdesc, dminfo, addtoparent)
         self._makerow()
 
@@ -1731,7 +1731,7 @@ class table(Table):
                 tx = 0;
                 os.system ('casabrowser ' + tempname + waitstr1)
                 if wait:
-                    from pyrap.tables import tabledelete
+                    from casacore.tables import tabledelete
                     print "  finished browsing"
                     tabledelete (tempname);
 
@@ -1816,7 +1816,7 @@ class table(Table):
                     os.system ('casaviewer ' + tempname + waitstr1)
                     viewed = True
                     if wait:
-                        from pyrap.tables import tabledelete
+                        from casacore.tables import tabledelete
                         print "  finished viewing"
                         tabledelete (tempname);
                     else:

--- a/casacore/tables/wxtablebrowser.py
+++ b/casacore/tables/wxtablebrowser.py
@@ -86,7 +86,7 @@ class CasaTestFrame(wxFrame):
 if __name__ == '__main__':
     import sys
     app = wxPySimpleApp()
-    from pyrap_tables import table as casatable
+    from casacore.tables import table as casatable
     casatab = casatable('/nfs/aips++/data/atnf/scripts/C972.ms')
     frame = CasaTestFrame(None, sys.stdout, casatab)
     frame.Show(True)

--- a/casacore/util/__init__.py
+++ b/casacore/util/__init__.py
@@ -1,4 +1,4 @@
 """
-Utilities for pyrap modules.
+Utilities for casacore modules.
 """
 from substitute import substitute, getlocals, getvariable


### PR DESCRIPTION
Mainly necessary for fixing imports on systems that do not
already have pyrap installed, which would be most systems
that install python-casacore because pyrap is now deprecated.