### PR TITLE
Use absolute imports as much as possible to appease Python3

### DIFF
--- a/casacore/fitting/__init__.py
+++ b/casacore/fitting/__init__.py
@@ -404,4 +404,4 @@ given::
     >>> dfit.solution(fid=id2)
 
 """
-from fitting import *
+from .fitting import *

--- a/casacore/fitting/fitting.py
+++ b/casacore/fitting/fitting.py
@@ -1,4 +1,4 @@
-from _fitting import fitting
+from ._fitting import fitting
 from casacore.functionals import *
 from casacore import six
 import numpy as NUM

--- a/casacore/functionals/__init__.py
+++ b/casacore/functionals/__init__.py
@@ -79,5 +79,5 @@ The functions created can also be used to specify the function to be fitted
 in a least squares fit.
 
 """
-from functional import *
+from .functional import *
 

--- a/casacore/functionals/functional.py
+++ b/casacore/functionals/functional.py
@@ -1,5 +1,5 @@
 import numpy
-from _functionals import _functional
+from ._functionals import _functional
 
 class functional(_functional):
     def __init__(self, name=None, order=-1, params=None, mode=None, dtype=0):

--- a/casacore/images/__init__.py
+++ b/casacore/images/__init__.py
@@ -56,4 +56,4 @@ The following functionality exists:
 
 
 # Make image interface available.
-from image import image
+from .image import image

--- a/casacore/images/image.py
+++ b/casacore/images/image.py
@@ -26,7 +26,7 @@
 # $Id$
 
 # Make interface to class ImageProxy available.
-from _images import Image
+from ._images import Image
 import numpy
 try:
     import numpy.ma as nma

--- a/casacore/measures/__init__.py
+++ b/casacore/measures/__init__.py
@@ -28,7 +28,7 @@ __all__ = ['is_measure', 'measures']
 
 import os
 import casacore.quanta as dq
-from  _measures import measures as _measures
+from  ._measures import measures as _measures
 
 if os.environ.has_key("MEASURESDATA"):
     if not os.environ.has_key("AIPSPATH"):

--- a/casacore/quanta/__init__.py
+++ b/casacore/quanta/__init__.py
@@ -1,4 +1,4 @@
-from quantity import quantity, is_quantity
-from _quanta import *
+from .quantity import quantity, is_quantity
+from ._quanta import *
 constants = constants()
 del Quantity, QuantVec, from_string, from_dict_v

--- a/casacore/quanta/quantity.py
+++ b/casacore/quanta/quantity.py
@@ -1,7 +1,7 @@
 import datetime
-from _quanta import Quantity
-from _quanta import QuantVec
-from _quanta import from_string, from_dict, from_dict_v
+from ._quanta import Quantity
+from ._quanta import QuantVec
+from ._quanta import from_string, from_dict, from_dict_v
 
 def is_quantity(q):
     """Indicate whether the object is a valid quantity"""

--- a/casacore/tables/__init__.py
+++ b/casacore/tables/__init__.py
@@ -57,12 +57,12 @@ submodule `msutil <#measurementset-utility-functions>`_
 
 """
 
-from table import table
-from table import tablecommand
-from table import taql
-from tableiter import tableiter
-from tableindex import tableindex
-from tablecolumn import tablecolumn
-from tablerow import tablerow
-from tableutil import *
-from msutil import *
+from .table import table
+from .table import tablecommand
+from .table import taql
+from .tableiter import tableiter
+from .tableindex import tableindex
+from .tablecolumn import tablecolumn
+from .tablerow import tablerow
+from .tableutil import *
+from .msutil import *

--- a/casacore/tables/table.py
+++ b/casacore/tables/table.py
@@ -41,8 +41,8 @@ Several utility functions exist. Important ones are:
 
 
 # Make interface to class TableProxy available.
-from _tables import Table
-from tablehelper import _add_prefix, _remove_prefix, _do_remove_prefix
+from ._tables import Table
+from .tablehelper import _add_prefix, _remove_prefix, _do_remove_prefix
 from casacore import six
 
 # Execute a TaQL command on a table.
@@ -334,7 +334,7 @@ class table(Table):
 
     def _makerow (self):
         """Internal method to make its tablerow object."""
-        from tablerow import _tablerow;
+        from .tablerow import _tablerow;
         self._row = _tablerow (self, []);
     
     def __str__ (self):
@@ -412,7 +412,7 @@ class table(Table):
           t.DATA[0:10]   # does the same in an easier way
 
         """
-        from tablecolumn import tablecolumn;
+        from .tablecolumn import tablecolumn;
         return tablecolumn (self, columnname);
 
     def row (self, columnnames=[], exclude=False):
@@ -422,7 +422,7 @@ class table(Table):
         more rows.
 
         """
-        from tablerow import tablerow;
+        from .tablerow import tablerow;
         return tablerow (self, columnnames, exclude);
 
     def iter (self, columnnames, order='', sort=True):
@@ -447,7 +447,7 @@ class table(Table):
             print ts.nrows()
 
         """
-        from tableiter import tableiter;
+        from .tableiter import tableiter;
         return tableiter (self, columnnames, order, sort);
 
     def index (self, columnnames, sort=True):
@@ -466,7 +466,7 @@ class table(Table):
           print tinx.rownumbers(0)       # print rownrs containing ANTENNA1=0
 
         """
-        from tableindex import tableindex;
+        from .tableindex import tableindex;
         return tableindex (self, columnnames, sort);
 
     def flush (self, recursive=False):

--- a/casacore/tables/tablecolumn.py
+++ b/casacore/tables/tablecolumn.py
@@ -25,8 +25,8 @@
 #
 # $Id: tablecolumn.py,v 1.9 2007/08/28 07:22:18 gvandiep Exp $
 
-from tablehelper import _check_key_slice, _do_remove_prefix
-from table import table
+from .tablehelper import _check_key_slice, _do_remove_prefix
+from .table import table
 
 
 class tablecolumn:
@@ -217,12 +217,12 @@ class tablecolumn:
 
     def iter (self, order='', sort=True):
         """Return a :class:`tableiter` object on this column."""
-        from tables import tableiter;
+        from casacore.tables import tableiter;
         return tableiter (self._table, [self._column], order, sort);
 
     def index (self, sort=True):
         """Return a :class:`tableindex` object on this column."""
-        from tables import tableindex;
+        from casacore.tables import tableindex;
         return tableindex (self._table, [self._column], sort);
 
     def __len__ (self):

--- a/casacore/tables/tableindex.py
+++ b/casacore/tables/tableindex.py
@@ -26,7 +26,7 @@
 # $Id: tableindex.py,v 1.6 2006/11/08 00:12:55 gvandiep Exp $
 
 # Make interface to class TableIndexProxy available.
-from _tables import TableIndex
+from ._tables import TableIndex
 
 class tableindex(TableIndex):
     """ The Python interface to Casacore table index

--- a/casacore/tables/tableiter.py
+++ b/casacore/tables/tableiter.py
@@ -26,8 +26,8 @@
 # $Id: tableiter.py,v 1.6 2006/12/11 02:46:08 gvandiep Exp $
 
 # Make interface to class TableIterProxy available.
-from _tables import TableIter
-from table import table;
+from ._tables import TableIter
+from .table import table;
 
 class tableiter(TableIter):
     """The Python interface to Casacore table iterators

--- a/casacore/tables/tablerow.py
+++ b/casacore/tables/tablerow.py
@@ -26,8 +26,8 @@
 # $Id: tablerow.py,v 1.6 2007/08/28 07:22:18 gvandiep Exp $
 
 # Make interface to class TableRowProxy available.
-from _tables import TableRow
-from tablehelper import _check_key_slice
+from ._tables import TableRow
+from .tablehelper import _check_key_slice
 
 # A normal tablerow object keeps a reference to a table object to be able
 # to know the actual number of rows.

--- a/casacore/tables/tableutil.py
+++ b/casacore/tables/tableutil.py
@@ -25,8 +25,8 @@
 #
 
 
-from table import table
-from tablehelper import _remove_prefix, _value_type_name
+from .table import table
+from .tablehelper import _remove_prefix, _value_type_name
 from casacore import six
 
 

--- a/casacore/util/__init__.py
+++ b/casacore/util/__init__.py
@@ -1,4 +1,4 @@
 """
 Utilities for casacore modules.
 """
-from substitute import substitute, getlocals, getvariable
+from .substitute import substitute, getlocals, getvariable


### PR DESCRIPTION
To enable proper imports of sub modules, I use absolute imports pretty much everywhere. This should be able to run on Python versions 2.5 and higher.