### PR TITLE
os.environ is not a dict: has no "has_key()" method

### DIFF
--- a/casacore/measures/__init__.py
+++ b/casacore/measures/__init__.py
@@ -30,9 +30,9 @@ import os
 import casacore.quanta as dq
 from  ._measures import measures as _measures
 
-if os.environ.has_key("MEASURESDATA"):
-    if not os.environ.has_key("AIPSPATH"):
-        os.environ["AIPSPATH"] = "%s dummy dummy" %  os.environ["MEASURESDATA"]
+if 'MEASURESDATA' in os.environ.keys():
+    if 'AIPSPATH' not in os.environ.keys():
+        os.environ['AIPSPATH'] = '%s dummy dummy' %  os.environ['MEASURESDATA']
 
 def is_measure(v):
     """


### PR DESCRIPTION
It is a mappable that implements the __contains__ method. It does not
have a has_key() method. I therefore replaced all instances of os.environ.has_key(...)
with 'keyname' in os.environ.keys().