### PR TITLE
Make tables print their columns and the number of rows

### DIFF
--- a/casacore/tables/table.py
+++ b/casacore/tables/table.py
@@ -338,8 +338,9 @@ class table(Table):
         self._row = _tablerow (self, []);
     
     def __str__ (self):
-        """Return the table name."""
-        return _add_prefix (self.name());
+        """Return the table name and the basic statistics"""
+        return _add_prefix (self.name()) + "\n%d rows"%self.nrows() + "\n" + \
+          "%d columns: "%len(self.colnames())+" ".join(self.colnames());
     
     def __len__ (self):
         """Return the number of rows in the table."""


### PR DESCRIPTION
For a bit more user friendliness, we could print the number of rows and all column names for table objects.