### PR TITLE
Quanta: add dicts with all units and prefixes

### DIFF
--- a/casacore/quanta/__init__.py
+++ b/casacore/quanta/__init__.py
@@ -1,4 +1,6 @@
 from .quantity import quantity, is_quantity
 from ._quanta import *
 constants = constants()
+units = units()
+prefixes = prefixes()
 del Quantity, QuantVec, from_string, from_dict_v

--- a/doc/casacore_quanta.rst
+++ b/doc/casacore_quanta.rst
@@ -56,6 +56,10 @@ square brackets is optional. There are examples after the list.
     * dd[-]mmm[-][cc]yy[/time] - gives the UTC time at the specified instant
                                  in calendar style notation (23-jun-1999)
 
+All possible units are visible in the dict `casacore.quanta.constants.units`,
+and all possible prefixes (all SI prefixes) are in the dict 
+`casacore.quanta.constants.prefixes`.
+
 Note that the standard unit for degrees is 'deg', and for days 'd'. Formatting
 is done in such a way that it interprets a 'd' as degrees if preceded by a
 value without a period and if any value following it is terminated with an 'm'.

--- a/tests/test_quanta.py
+++ b/tests/test_quanta.py
@@ -34,3 +34,7 @@ class TestQuanta(unittest.TestCase):
         print q3.formatted("ANGLE")
         print q3.to_string("%0.3f")
 
+        self.assertIn('Jy', units)
+        self.assertEqual(units['Jy'], ['jansky', quantity(1e-26, 'kg.s-2')])
+        self.assertIn('a',prefixes)
+        self.assertEqual(prefixes['a'],['atto',1e-18])


### PR DESCRIPTION
With this change (and after casacore/casacore#300 gets merged), you get
```
import casacore.quanta

casacore.quanta.units

{'"': ['arcsec', '4.84814e-06 rad'],
 '"_2': ['square arcsec', '2.35044e-11 sr'],
 '$': ['currency', '1 _'],
 '%': ['percent', '0.01'],
 '%%': ['permille', '0.001'],
 "'": ['arcmin', '0.000290888 rad'],
 "''": ['arcsec', '4.84814e-06 rad'],
 "''_2": ['square arcsec', '2.35044e-11 sr'],
 "'_2": ['square arcmin', '8.46159e-08 sr'],
 ':': ['hour', '3600 s'],
 '::': ['minute', '60 s'],
 ':::': ['second', '1 s'],
 'A': ['ampere', '1 A'],
 'AE': ['astronomical unit', '1.49598e+11 m'],
 'AU': ['astronomical unit', '1.49598e+11 m'],
 'Ah': ['ampere hour', '3600 s.A'],
 'Angstrom': ['angstrom', '1e-10 m'],
 'Bq': ['becquerel', '1 s-1'],
 'Btu': ['British thermal unit (Int)', '1055.06 m2.kg.s-2'],
 'C': ['coulomb', '1 s.A'],
 'CM': ['metric carat', '0.0002 kg'],
 'Cal': ['large calorie (Int)', '4186.8 m2.kg.s-2'],
 'F': ['farad', '1 m-2.kg-1.s4.A2'],
 'FU': ['flux unit', '1e-26 kg.s-2'],
 'G': ['gauss', '0.0001 kg.s-2.A-1'],
 'Gal': ['gal', '0.01 m.s-2'],
 'Gb': ['gilbert', '0.795775 A'],
 'Gy': ['gray', '1 m2.s-2'],
 'H': ['henry', '1 m2.kg.s-2.A-2'],
 'Hz': ['hertz', '1 s-1'],
 'J': ['joule', '1 m2.kg.s-2'],
 'Jy': ['jansky', '1e-26 kg.s-2'],
 'K': ['kelvin', '1 K'],
 'L': ['litre', '0.001 m3'],
 'M0': ['solar mass', '1.98892e+30 kg'],
 'Mx': ['maxwell', '1e-08 m2.kg.s-2.A-1'],
 'N': ['newton', '1 m.kg.s-2'],
 'Oe': ['oersted', '79.5775 m-1.A'],
 'Ohm': ['ohm', '1 m2.kg.s-3.A-2'],
 'Pa': ['pascal', '1 m-1.kg.s-2'],
 'R': ['mile', '0.000258 kg-1.s.A'],
 'S': ['siemens', '1 m-2.kg-1.s3.A2'],
 'S0': ['solar mass', '1.98892e+30 kg'],
 'St': ['stokes', '0.0001 m2.s-1'],
 'Sv': ['sievert', '1 m2.s-2'],
 'T': ['tesla', '1 kg.s-2.A-1'],
 'Torr': ['torr', '133.322 m-1.kg.s-2'],
 'UA': ['astronomical unit', '1.49598e+11 m'],
 'USfl_oz': ['fluid ounce (US)', '2.95735e-05 m3'],
 'USgal': ['gallon (US)', '0.00378541 m3'],
 'V': ['volt', '1 m2.kg.s-3.A-1'],
 'W': ['watt', '1 m2.kg.s-3'],
 'WU': ['WSRT flux unit', '5e-29 kg.s-2'],
 'Wb': ['weber', '1 m2.kg.s-2.A-1'],
 '_': ['undimensioned', '1 _'],
 'a': ['year', '3.15576e+07 s'],
 'abA': ['abampere', '10 A'],
 'abC': ['abcoulomb', '10 s.A'],
 'abF': ['abfarad', '1e+09 m-2.kg-1.s4.A2'],
 'abH': ['abhenry', '1e-09 m2.kg.s-2.A-2'],
 'abOhm': ['abohm', '1e-09 m2.kg.s-3.A-2'],
 'abV': ['abvolt', '1e-08 m2.kg.s-3.A-1'],
 'ac': ['acre', '4046.86 m2'],
 'adu': ['dimensionless ADC unit', '1 _'],
 'arcmin': ['arcmin', '0.000290888 rad'],
 'arcmin_2': ['square arcmin', '8.46159e-08 sr'],
 'arcsec': ['arcsec', '4.84814e-06 rad'],
 'arcsec_2': ['square arcsec', '2.35044e-11 sr'],
 'as': ['arcsec', '4.84814e-06 rad'],
 'ata': ['technical atmosphere', '98066.5 m-1.kg.s-2'],
 'atm': ['standard atmosphere', '101325 m-1.kg.s-2'],
 'bar': ['bar', '100000 m-1.kg.s-2'],
 'beam': ['undefined beam area', '1 _'],
 'cal': ['calorie (Int)', '4.1868 m2.kg.s-2'],
 'cd': ['candela', '1 cd'],
 'count': ['count', '1 _'],
 'cwt': ['hundredweight', '50.8023 kg'],
 'cy': ['century', '3.15576e+09 s'],
 'd': ['day', '86400 s'],
 'debye': ['statvolt', '3.33564e-29 m.s.A'],
 'deg': ['degree', '0.0174533 rad'],
 'deg_2': ['square degree', '0.000304617 sr'],
 'dyn': ['dyne', '1e-05 m.kg.s-2'],
 'eV': ['electron volt', '1.60218e-19 m2.kg.s-2'],
 'erg': ['erg', '1e-07 m2.kg.s-2'],
 'fl_oz': ['fluid ounce (Imp)', '2.8413e-05 m3'],
 'ft': ['foot', '0.3048 m'],
 'fu': ['flux unit', '1e-26 kg.s-2'],
 'fur': ['furlong', '201.168 m'],
 'g': ['gram', '0.001 kg'],
 'gal': ['gallon (Imp)', '0.00454609 m3'],
 'h': ['hour', '3600 s'],
 'ha': ['hectare', '10000 m2'],
 'hp': ['horsepower', '745.7 m2.kg.s-3'],
 'in': ['inch', '0.0254 m'],
 'kg': ['kilogram', '1 kg'],
 'kn': ['knot (Imp)', '0.514773 m.s-1'],
 'l': ['litre', '0.001 m3'],
 'lambda': ['lambda', '1 _'],
 'lb': ['pound (avoirdupois)', '0.453592 kg'],
 'lm': ['lumen', '1 cd.sr'],
 'lx': ['lux', '1 m-2.cd.sr'],
 'ly': ['light year', '9.46073e+15 m'],
 'm': ['metre', '1 m'],
 'mHg': ['metre of mercury', '133322 m-1.kg.s-2'],
 'mile': ['mile', '1609.34 m'],
 'min': ['minute', '60 s'],
 'mol': ['mole', '1 mol'],
 'n_mile': ['nautical mile (Imp)', '1853.18 m'],
 'oz': ['ounce (avoirdupois)', '0.0283495 kg'],
 'pc': ['parsec', '3.08568e+16 m'],
 'pixel': ['pixel', '1 _'],
 'rad': ['radian', '1 rad'],
 's': ['second', '1 s'],
 'sb': ['stilb', '10000 m-2.cd'],
 'sq_arcmin': ['square arcmin', '8.46159e-08 sr'],
 'sq_arcsec': ['square arcsec', '2.35044e-11 sr'],
 'sq_deg': ['square degree', '0.000304617 sr'],
 'sr': ['steradian', '1 sr'],
 'statA': ['statampere', '3.33564e-10 A'],
 'statC': ['statcoulomb', '3.33564e-10 s.A'],
 'statF': ['statfarad', '1.11188e-12 m-2.kg-1.s4.A2'],
 'statH': ['stathenry', '8.99377e+11 m2.kg.s-2.A-2'],
 'statOhm': ['statohm', '8.99377e+11 m2.kg.s-3.A-2'],
 'statV': ['statvolt', '299.792 m2.kg.s-3.A-1'],
 't': ['tonne', '1000 kg'],
 'u': ['atomic mass unit', '1.661e-27 kg'],
 'yd': ['yard', '0.9144 m'],
 'yr': ['year', '3.15576e+07 s']}

casacore.quanta.prefixes

{'E': ['exa', '1e+18'],
 'G': ['giga', '1e+09'],
 'M': ['mega', '1e+06'],
 'P': ['peta', '1e+15'],
 'T': ['tera', '1e+12'],
 'Y': ['yotta', '1e+24'],
 'Z': ['zetta', '1e+21'],
 'a': ['atto', '1e-18'],
 'c': ['centi', '0.01'],
 'd': ['deci', '0.1'],
 'da': ['deka', '10'],
 'f': ['femto', '1e-15'],
 'h': ['hecto', '100'],
 'k': ['kilo', '1000'],
 'm': ['milli', '0.001'],
 'n': ['nano', '1e-09'],
 'p': ['pico', '1e-12'],
 'u': ['micro', '1e-06'],
 'y': ['yocto', '1e-24'],
 'z': ['zepto', '1e-21']}
```