### PR TITLE
Add dependency on casacore libs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,8 @@ extension_metas = (
 # Find casacore libpath
 found_casacore_libraries=True;
 if not find_library_file('casa_casa'):
-    print("Warning: could not find casa library dir for dependency tracking")
+    print("Warning: could not find casa library dir for dependency tracking.")
+    print("Possibly not rebuilding. Specify --force to force a rebuild.")
     found_casacore_libraries=False
 
 extensions = []


### PR DESCRIPTION
This should fix #25 in most cases, by adding the library files to the dependencies. Finding the full path is actually done by the compiler. I tried to mimic the search path, but can't guarantee that always works. If the libraries are not found, the dependency is not added and the old behavior is kept (so no error is thrown).