### PR TITLE
Quanta: add dicts with all units and prefixes with Python 2.6 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ before_install:
 - sudo apt-get update -qq
 - sudo apt-get install libcasacore2-dev casacore-data
 install:
-- python setup.py develop
+- pip install -r test_requirements.txt
+- pip install -e .
 script:
 - nosetests
 deploy:

--- a/casacore/quanta/__init__.py
+++ b/casacore/quanta/__init__.py
@@ -1,4 +1,6 @@
 from .quantity import quantity, is_quantity
 from ._quanta import *
 constants = constants()
+units = units()
+prefixes = prefixes()
 del Quantity, QuantVec, from_string, from_dict_v

--- a/doc/casacore_quanta.rst
+++ b/doc/casacore_quanta.rst
@@ -56,6 +56,10 @@ square brackets is optional. There are examples after the list.
     * dd[-]mmm[-][cc]yy[/time] - gives the UTC time at the specified instant
                                  in calendar style notation (23-jun-1999)
 
+All possible units are visible in the dict `casacore.quanta.constants.units`,
+and all possible prefixes (all SI prefixes) are in the dict 
+`casacore.quanta.constants.prefixes`.
+
 Note that the standard unit for degrees is 'deg', and for days 'd'. Formatting
 is done in such a way that it interprets a 'd' as degrees if preceded by a
 value without a period and if any value following it is terminated with an 'm'.

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,4 @@
+nose
+unittest2
+coverage
+

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -1,4 +1,4 @@
-import unittest
+import unittest2 as unittest
 from casacore import fitting
 
 

--- a/tests/test_funcionals.py
+++ b/tests/test_funcionals.py
@@ -1,4 +1,4 @@
-import unittest
+import unittest2 as unittest
 from casacore import functionals
 
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,4 +1,4 @@
-import unittest
+import unittest2 as unittest
 from casacore.images import *
 import numpy
 import tempfile

--- a/tests/test_measures.py
+++ b/tests/test_measures.py
@@ -1,4 +1,4 @@
-import unittest
+import unittest2 as unittest
 from casacore import measures
 
 

--- a/tests/test_quanta.py
+++ b/tests/test_quanta.py
@@ -1,4 +1,4 @@
-import unittest
+import unittest2 as unittest
 from math import sin
 from pyrap.quanta import *
 
@@ -34,3 +34,7 @@ class TestQuanta(unittest.TestCase):
         print q3.formatted("ANGLE")
         print q3.to_string("%0.3f")
 
+        self.assertIn('Jy', units)
+        self.assertEqual(units['Jy'], ['jansky', quantity(1e-26, 'kg.s-2')])
+        self.assertIn('a',prefixes)
+        self.assertEqual(prefixes['a'],['atto',1e-18])

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,4 +1,4 @@
-import unittest
+import unittest2 as unittest
 from pyrap.tables import *
 import numpy
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,4 @@
-import unittest
+import unittest2 as unittest
 from pyrap.util import substitute
 
 


### PR DESCRIPTION
fix for this PR

https://github.com/casacore/python-casacore/pull/39