### PR TITLE
Add methods for creating a default MS

### DIFF
--- a/casacore/tables/__init__.py
+++ b/casacore/tables/__init__.py
@@ -59,6 +59,7 @@ submodule `msutil <#measurementset-utility-functions>`_
 
 from .msutil import *
 from .table import table
+from .table import default_ms
 from .table import tablecommand
 from .table import taql
 from .tablecolumn import tablecolumn

--- a/casacore/tables/__init__.py
+++ b/casacore/tables/__init__.py
@@ -60,6 +60,7 @@ submodule `msutil <#measurementset-utility-functions>`_
 from .msutil import *
 from .table import table
 from .table import default_ms
+from .table import default_ms_subtable
 from .table import tablecommand
 from .table import taql
 from .tablecolumn import tablecolumn

--- a/casacore/tables/msutil.py
+++ b/casacore/tables/msutil.py
@@ -26,9 +26,21 @@
 
 import numpy as np
 from casacore import six
-from casacore.tables.table import table, taql
+from casacore.tables.table import table, taql, _required_ms_desc
 from casacore.tables.tableutil import makescacoldesc, makearrcoldesc, \
     makecoldesc, maketabdesc
+
+
+def required_ms_desc(table=None):
+    """
+    Obtain the required descriptor for creating
+    """
+
+    # Default to MAIN table
+    if column is None:
+        column = ""
+
+    return _required_ms_desc(column)
 
 
 def addImagingColumns(msname, ack=True):

--- a/casacore/tables/msutil.py
+++ b/casacore/tables/msutil.py
@@ -33,14 +33,16 @@ from casacore.tables.tableutil import makescacoldesc, makearrcoldesc, \
 
 def required_ms_desc(table=None):
     """
-    Obtain the required descriptor for creating
+    Obtain the required table description for a given table.
+    If "" or "MAIN", the description for a MeasurementSet is returned.
+    Otherwise, a the description for a MeasurementSet subtable is returned.
     """
 
     # Default to MAIN table
-    if column is None:
-        column = ""
+    if table is None:
+        table = ""
 
-    return _required_ms_desc(column)
+    return _required_ms_desc(table)
 
 
 def addImagingColumns(msname, ack=True):

--- a/casacore/tables/table.py
+++ b/casacore/tables/table.py
@@ -40,18 +40,46 @@ Several utility functions exist. Important ones are:
 """
 
 # Make interface to class TableProxy available.
-from ._tables import Table, _default_ms, _required_ms_desc
+from ._tables import (Table,
+  _default_ms,
+  _default_ms_subtable,
+  _required_ms_desc)
 
 from casacore import six
 from .tablehelper import _add_prefix, _remove_prefix, _do_remove_prefix
 
-def default_ms(name, required_td=None):
+def default_ms(name, tabdesc=None):
+  """
+  Creates a default Measurement Set called name. Any Table Description
+  elements in tabdesc will overwrite the corresponding element in a default
+  Measurement Set Table Description (columns, hypercolumns and keywords).
+
+  In practice, you probably want to specify columns such as DATA, MODEL_DATA
+  and CORRECTED_DATA (and their associated keywords and hypercolumns) in tabdesc
+  """
+
   # Default
-  if required_td is None:
-    required_td = {}
+  if tabdesc is None:
+    tabdesc = {}
 
   # Wrap the Table object
-  return table(_default_ms(name, required_td), _oper=3)
+  return table(_default_ms(name, tabdesc), _oper=3)
+
+def default_ms_subtable(subtable, tabdesc=None):
+  """
+  Creates a default Measurement Set subtable. Any Table Description
+  elements in tabdesc will overwrite the corresponding element in a default
+  Measurement Set Table Description (columns, hypercolumns and keywords).
+
+if subtable is "" or "MAIN" a standard MeasurementSet with subtables will
+be created.
+  """
+
+  if tabdesc is None:
+    tabdesc = {}
+
+  # Wrap the Table object
+  return table(_default_ms_subtable(subtable, tabdesc), _oper=3)
 
 # Execute a TaQL command on a table.
 def taql(command, style='Python', tables=[], globals={}, locals={}):

--- a/casacore/tables/table.py
+++ b/casacore/tables/table.py
@@ -1427,7 +1427,20 @@ class table(Table):
         :func:`maketabdesc` is returned.
 
         """
-        return self._getdesc(actual, True)
+
+        tabledesc = self._getdesc(actual, True)
+
+        # Strip out 0 length "HCcoordnames" and "HCidnames"
+        # as these aren't valid. (See tabledefinehypercolumn)
+        hcdefs = tabledesc.get('_define_hypercolumn_', {})
+
+        for c, hcdef in hcdefs.iteritems():
+          if "HCcoordnames" in hcdef and len(hcdef["HCcoordnames"]) == 0:
+            del hcdef["HCcoordnames"]
+          if "HCidnames" in hcdef and len(hcdef["HCidnames"]) == 0:
+            del hcdef ["HCidnames"]
+
+        return tabledesc
 
     def getcoldesc(self, columnname, actual=True):
         """Get the description of a column.

--- a/casacore/tables/table.py
+++ b/casacore/tables/table.py
@@ -40,11 +40,18 @@ Several utility functions exist. Important ones are:
 """
 
 # Make interface to class TableProxy available.
-from ._tables import Table
+from ._tables import Table, _default_ms, _required_ms_desc
 
 from casacore import six
 from .tablehelper import _add_prefix, _remove_prefix, _do_remove_prefix
 
+def default_ms(name, required_td=None):
+  # Default
+  if required_td is None:
+    required_td = {}
+
+  # Wrap the Table object
+  return table(_default_ms(name, required_td), _oper=3)
 
 # Execute a TaQL command on a table.
 def taql(command, style='Python', tables=[], globals={}, locals={}):
@@ -481,9 +488,9 @@ class table(Table):
         """Flush the table to disk.
 
         Until a flush or unlock is performed, the results of operations might
-        not be stored on disk yet. 
+        not be stored on disk yet.
         | If `recursive=True`, all subtables are flushed as well.
-            
+
         """
         self._flush(recursive)
 
@@ -613,7 +620,7 @@ class table(Table):
         The other arguments can be used to specify where to start copying.
         By default the entire input table is appended to the output table.
         Rows are added to the output table if needed.
-        
+
         `startrowin`
           Row where to start in the input table.
         `startrowout`
@@ -628,7 +635,7 @@ class table(Table):
 
           t:=table('test.ms',readonly=F)
           t.copyrows(t)
-        
+
         """
         self._copyrows(outtable, startrowin, startrowout, nrow)
 
@@ -672,7 +679,7 @@ class table(Table):
         """Return the lockoptions.
 
         They are returned as a dict with fields:
-        
+
         'option'
           the locking mode (user, usernoread, auto, autonoread, permanent,
           permanentwait).
@@ -1308,7 +1315,7 @@ class table(Table):
         consisting of multiple parts separated by dots. This represents nested
         structs, thus puts the value into a field in a struct (in a struct,
         etc.).
-        If `makesubrecord=True` structs will be created for the keyword name 
+        If `makesubrecord=True` structs will be created for the keyword name
         parts that do not exist.
 
         Instead of a keyword name an index can be given which returns the value
@@ -1578,7 +1585,7 @@ class table(Table):
           commas have to be used to separate sort keys.
         `columns`
           The columns to be selected (projection in data base terms). It is a
-          single string in which commas have to be used to separate column 
+          single string in which commas have to be used to separate column
           names. Apart from column names, expressions can be given as well.
         `limit`
           If > 0, maximum number of rows to be selected.
@@ -1660,7 +1667,7 @@ class table(Table):
 
         `columns`
           The columns to be selected (projection in data base terms). It is a
-          single string in which commas have to be used to separate column 
+          single string in which commas have to be used to separate column
           names. Apart from column names, expressions can be given as well.
         `name`
           The name of the reference table if it is to be made persistent.
@@ -1674,11 +1681,11 @@ class table(Table):
         return tablecommand(command, style, [self])
 
     def calc(self, expr, style='Python'):
-        """Do a TaQL calculation 
-        
+        """Do a TaQL calculation
+
         The TaQL CALC command can be used to get the result of a calculation on
         table data. It is, however, also possible to use it without table data.
-        
+
         For instance, to use it for converting units::
 
           t = table('',{})
@@ -1712,7 +1719,7 @@ class table(Table):
         function.
 
         If `wait=False`, the casabrowser is started in the background.
-        In that case the user should delete a possibly created copy of a 
+        In that case the user should delete a possibly created copy of a
         temporary table.
 
         """
@@ -1791,7 +1798,7 @@ class table(Table):
         function.
 
         If `wait=False`, the casaviewer is started in the background.
-        In that case the user should delete a possibly created copy of a 
+        In that case the user should delete a possibly created copy of a
         temporary table.
 
         """

--- a/casacore/tables/table.py
+++ b/casacore/tables/table.py
@@ -48,7 +48,7 @@ from ._tables import (Table,
 from casacore import six
 from .tablehelper import _add_prefix, _remove_prefix, _do_remove_prefix
 
-def default_ms(name, tabdesc=None):
+def default_ms(name, tabdesc=None, dminfo=None):
   """
   Creates a default Measurement Set called name. Any Table Description
   elements in tabdesc will overwrite the corresponding element in a default
@@ -58,28 +58,35 @@ def default_ms(name, tabdesc=None):
   and CORRECTED_DATA (and their associated keywords and hypercolumns) in tabdesc
   """
 
-  # Default
+  # Default to empty dictionaries
   if tabdesc is None:
     tabdesc = {}
 
-  # Wrap the Table object
-  return table(_default_ms(name, tabdesc), _oper=3)
+  if dminfo is None:
+    dminfo = {}
 
-def default_ms_subtable(subtable, tabdesc=None):
+  # Wrap the Table object
+  return table(_default_ms(name, tabdesc, dminfo), _oper=3)
+
+def default_ms_subtable(subtable, tabdesc=None, dminfo=None):
   """
   Creates a default Measurement Set subtable. Any Table Description
   elements in tabdesc will overwrite the corresponding element in a default
   Measurement Set Table Description (columns, hypercolumns and keywords).
 
-if subtable is "" or "MAIN" a standard MeasurementSet with subtables will
-be created.
+  if subtable is "" or "MAIN" a standard MeasurementSet with subtables will
+  be created.
   """
 
+  # Default to empty dictionaries
   if tabdesc is None:
     tabdesc = {}
 
+  if dminfo is None:
+    dminfo = {}
+
   # Wrap the Table object
-  return table(_default_ms_subtable(subtable, tabdesc), _oper=3)
+  return table(_default_ms_subtable(subtable, tabdesc, dminfo), _oper=3)
 
 # Execute a TaQL command on a table.
 def taql(command, style='Python', tables=[], globals={}, locals={}):

--- a/casacore/tables/table.py
+++ b/casacore/tables/table.py
@@ -68,15 +68,21 @@ def default_ms(name, tabdesc=None, dminfo=None):
   # Wrap the Table object
   return table(_default_ms(name, tabdesc, dminfo), _oper=3)
 
-def default_ms_subtable(subtable, tabdesc=None, dminfo=None):
+def default_ms_subtable(subtable, name=None, tabdesc=None, dminfo=None):
   """
   Creates a default Measurement Set subtable. Any Table Description
   elements in tabdesc will overwrite the corresponding element in a default
   Measurement Set Table Description (columns, hypercolumns and keywords).
 
+  if name is given, it will be treated as a path that the table should
+  be created in. Set to subtable if None
+
   if subtable is "" or "MAIN" a standard MeasurementSet with subtables will
   be created.
   """
+
+  if name is None:
+    name = subtable
 
   # Default to empty dictionaries
   if tabdesc is None:
@@ -86,7 +92,7 @@ def default_ms_subtable(subtable, tabdesc=None, dminfo=None):
     dminfo = {}
 
   # Wrap the Table object
-  return table(_default_ms_subtable(subtable, tabdesc, dminfo), _oper=3)
+  return table(_default_ms_subtable(subtable, name, tabdesc, dminfo), _oper=3)
 
 # Execute a TaQL command on a table.
 def taql(command, style='Python', tables=[], globals={}, locals={}):

--- a/casacore/tables/tableutil.py
+++ b/casacore/tables/tableutil.py
@@ -528,8 +528,8 @@ def makedminfo(tabdesc, group_spec=None):
       continue
 
     # Extract group and data manager type
-    group = d['dataManagerGroup']
-    type_ = d['dataManagerType']
+    group = d.get("dataManagerGroup", "StandardStMan")
+    type_ = d.get("dataManagerType", "StandardStMan")
 
     # Set defaults if necessary
     if not group:

--- a/setup.py
+++ b/setup.py
@@ -107,9 +107,9 @@ extension_metas = (
     (
         "casacore.tables._tables",
         ["src/pytable.cc", "src/pytableindex.cc", "src/pytableiter.cc",
-         "src/pytablerow.cc", "src/tables.cc"],
+         "src/pytablerow.cc", "src/tables.cc", "src/pyms.cc"],
         ["src/tables.h"],
-        ['casa_tables', boost_python, casa_python],
+        ['casa_tables', 'casa_ms', boost_python, casa_python],
     )
 )
 

--- a/src/pyms.cc
+++ b/src/pyms.cc
@@ -30,76 +30,41 @@ namespace casacore {
     // Upper case things to be sure
     table_.upcase();
 
-    if(table_.empty() || table_ == "MAIN")
-    {
+    if(table_.empty() || table_ == "MAIN") {
       return MeasurementSet::requiredTableDesc();
-    }
-    else if(table_ == "ANTENNA")
-    {
+    } else if(table_ == "ANTENNA") {
       return MSAntenna::requiredTableDesc();
-    }
-    else if(table_ == "DATA_DESCRIPTION")
-    {
+    } else if(table_ == "DATA_DESCRIPTION") {
       return MSDataDescription::requiredTableDesc();
-    }
-    else if(table_ == "DOPPLER")
-    {
+    } else if(table_ == "DOPPLER") {
       return MSDoppler::requiredTableDesc();
-    }
-    else if(table_ == "FEED")
-    {
+    } else if(table_ == "FEED") {
       return MSFeed::requiredTableDesc();
-    }
-    else if(table_ == "FIELD")
-    {
+    } else if(table_ == "FIELD") {
       return MSField::requiredTableDesc();
-    }
-    else if(table_ == "FLAG_CMD")
-    {
+    } else if(table_ == "FLAG_CMD") {
       return MSFlagCmd::requiredTableDesc();
-    }
-    else if(table_ == "FREQ_OFFSET")
-    {
+    } else if(table_ == "FREQ_OFFSET") {
       return MSFreqOffset::requiredTableDesc();
-    }
-    else if(table_ == "HISTORY")
-    {
+    } else if(table_ == "HISTORY") {
       return MSHistory::requiredTableDesc();
-    }
-    else if(table_ == "OBSERVATION")
-    {
+    } else if(table_ == "OBSERVATION") {
       return MSObservation::requiredTableDesc();
-    }
-    else if(table_ == "POINTING")
-    {
+    } else if(table_ == "POINTING") {
       return MSPointing::requiredTableDesc();
-    }
-    else if(table_ == "POLARIZATION")
-    {
+    } else if(table_ == "POLARIZATION") {
       return MSPolarization::requiredTableDesc();
-    }
-    else if(table_ == "PROCESSOR")
-    {
+    } else if(table_ == "PROCESSOR") {
       return MSProcessor::requiredTableDesc();
-    }
-    else if(table_ == "SOURCE")
-    {
+    } else if(table_ == "SOURCE") {
       return MSSource::requiredTableDesc();
-    }
-    else if(table_ == "SPECTRAL_WINDOW")
-    {
+    } else if(table_ == "SPECTRAL_WINDOW") {
       return MSSpectralWindow::requiredTableDesc();
-    }
-    else if(table_ == "STATE")
-    {
+    } else if(table_ == "STATE") {
       return MSState::requiredTableDesc();
-    }
-    else if(table_ == "SYSCAL")
-    {
+    } else if(table_ == "SYSCAL") {
       return MSSysCal::requiredTableDesc();
-    }
-    else if(table_ == "WEATHER")
-    {
+    } else if(table_ == "WEATHER") {
       return MSWeather::requiredTableDesc();
     }
 
@@ -122,13 +87,11 @@ namespace casacore {
     TableDesc result = required_td;
 
     // Overwrite required columns with user columns
-    for(uInt i=0; i < user_td.ncolumn(); ++i)
-    {
+    for(uInt i=0; i < user_td.ncolumn(); ++i) {
       const String & name = user_td[i].name();
 
       // Remove if present in required
-      if(result.isColumn(name))
-      {
+      if(result.isColumn(name)) {
         result.removeColumn(name);
       }
 
@@ -141,11 +104,9 @@ namespace casacore {
     // doesn't define hypercolumns by default...
     Vector<String> user_hc = user_td.hypercolumnNames();
 
-    for(uInt i=0; i < user_hc.size(); ++i)
-    {
+    for(uInt i=0; i < user_hc.size(); ++i) {
       // Remove if hypercolumn is present
-      if(result.isHypercolumn(user_hc[i]))
-      {
+      if(result.isHypercolumn(user_hc[i])) {
         result.removeHypercolumnDesc(user_hc[i]);
       }
 
@@ -177,8 +138,7 @@ namespace casacore {
     TableDesc user_td;
 
     // Create Table Description object from extra user table description
-    if(!TableProxy::makeTableDesc(table_desc, user_td, msg))
-    {
+    if(!TableProxy::makeTableDesc(table_desc, user_td, msg)) {
       throw TableError("Error Making Table Description " + msg);
     }
 
@@ -203,84 +163,48 @@ namespace casacore {
     String table_ = subtable;
     table_.upcase();
 
-    if(name.empty() || name == "MAIN")
-    {
+    if(name.empty() || name == "MAIN") {
       name = "MeasurementSet.ms";
     }
 
     SetupNewTable setup_new_table = default_ms_factory(name,
       subtable, table_desc, dminfo);
 
-    if(table_.empty() || subtable == "MAIN")
-    {
+    if(table_.empty() || subtable == "MAIN") {
       return TableProxy(MeasurementSet(setup_new_table));
-    }
-    else if(table_ == "ANTENNA")
-    {
+    } else if(table_ == "ANTENNA") {
       return TableProxy(MSAntenna(setup_new_table));
-    }
-    else if(table_ == "DATA_DESCRIPTION")
-    {
+    } else if(table_ == "DATA_DESCRIPTION") {
       return TableProxy(MSDataDescription(setup_new_table));
-    }
-    else if(table_ == "DOPPLER")
-    {
+    } else if(table_ == "DOPPLER") {
       return TableProxy(MSDoppler(setup_new_table));
-    }
-    else if(table_ == "FEED")
-    {
+    } else if(table_ == "FEED") {
       return TableProxy(MSFeed(setup_new_table));
-    }
-    else if(table_ == "FIELD")
-    {
+    } else if(table_ == "FIELD") {
       return TableProxy(MSField(setup_new_table));
-    }
-    else if(table_ == "FLAG_CMD")
-    {
+    } else if(table_ == "FLAG_CMD") {
       return TableProxy(MSFlagCmd(setup_new_table));
-    }
-    else if(table_ == "FREQ_OFFSET")
-    {
+    } else if(table_ == "FREQ_OFFSET") {
       return TableProxy(MSFreqOffset(setup_new_table));
-    }
-    else if(table_ == "HISTORY")
-    {
+    } else if(table_ == "HISTORY") {
       return TableProxy(MSHistory(setup_new_table));
-    }
-    else if(table_ == "OBSERVATION")
-    {
+    } else if(table_ == "OBSERVATION") {
       return TableProxy(MSObservation(setup_new_table));
-    }
-    else if(table_ == "POINTING")
-    {
+    } else if(table_ == "POINTING") {
       return TableProxy(MSPointing(setup_new_table));
-    }
-    else if(table_ == "POLARIZATION")
-    {
+    } else if(table_ == "POLARIZATION") {
       return TableProxy(MSPolarization(setup_new_table));
-    }
-    else if(table_ == "PROCESSOR")
-    {
+    } else if(table_ == "PROCESSOR") {
       return TableProxy(MSProcessor(setup_new_table));
-    }
-    else if(table_ == "SOURCE")
-    {
+    } else if(table_ == "SOURCE") {
       return TableProxy(MSSource(setup_new_table));
-    }
-    else if(table_ == "SPECTRAL_WINDOW")
-    {
+    } else if(table_ == "SPECTRAL_WINDOW") {
       return TableProxy(MSSpectralWindow(setup_new_table));
-    }
-    else if(table_ == "STATE")
-    {
+    } else if(table_ == "STATE") {
       return TableProxy(MSState(setup_new_table));
-    }
-    else if(table_ == "SYSCAL")
-    {
+    } else if(table_ == "SYSCAL") {
       return TableProxy(MSSysCal(setup_new_table));
-    }
-    else if(table_ == "WEATHER")
-    {
+    } else if(table_ == "WEATHER") {
       return TableProxy(MSWeather(setup_new_table));
     }
 

--- a/src/pyms.cc
+++ b/src/pyms.cc
@@ -196,20 +196,19 @@ namespace casacore {
   }
 
   TableProxy default_ms_subtable(const String & subtable,
+                                String name,
                                 const Record & table_desc,
                                 const Record & dminfo)
   {
     String table_ = subtable;
     table_.upcase();
 
-    String name = table_;
-
     if(name.empty() || name == "MAIN")
     {
       name = "MeasurementSet.ms";
     }
 
-    SetupNewTable setup_new_table = default_ms_factory(subtable,
+    SetupNewTable setup_new_table = default_ms_factory(name,
       subtable, table_desc, dminfo);
 
     if(table_.empty() || subtable == "MAIN")

--- a/src/pyms.cc
+++ b/src/pyms.cc
@@ -169,8 +169,9 @@ namespace casacore {
   }
 
   SetupNewTable default_ms_factory(const String & name,
-    const String & subtable,
-    const Record & table_desc)
+                                  const String & subtable,
+                                  const Record & table_desc,
+                                  const Record & dminfo)
   {
     String msg;
     TableDesc user_td;
@@ -186,10 +187,17 @@ namespace casacore {
                         required_table_desc(subtable), user_td);
 
     // Return SetupNewTable object
-    return SetupNewTable(name, final_desc, Table::New);
+    SetupNewTable setup = SetupNewTable(name, final_desc, Table::New);
+
+    // Apply any data manager info
+    setup.bindCreate(dminfo);
+
+    return setup;
   }
 
-  TableProxy default_ms_subtable(const String & subtable, const Record & table_desc)
+  TableProxy default_ms_subtable(const String & subtable,
+                                const Record & table_desc,
+                                const Record & dminfo)
   {
     String table_ = subtable;
     table_.upcase();
@@ -201,7 +209,8 @@ namespace casacore {
       name = "MeasurementSet.ms";
     }
 
-    SetupNewTable setup_new_table = default_ms_factory(subtable, subtable, table_desc);
+    SetupNewTable setup_new_table = default_ms_factory(subtable,
+      subtable, table_desc, dminfo);
 
     if(table_.empty() || subtable == "MAIN")
     {
@@ -279,10 +288,13 @@ namespace casacore {
     throw TableError("Unknown table type: " + table_);
   }
 
-  TableProxy default_ms(const String & name, const Record & table_desc)
+  TableProxy default_ms(const String & name,
+                        const Record & table_desc,
+                        const Record & dminfo)
   {
     // Create the main Measurement Set
-    SetupNewTable setup_new_table = default_ms_factory(name, "MAIN", table_desc);
+    SetupNewTable setup_new_table = default_ms_factory(name,
+      "MAIN", table_desc, dminfo);
     MeasurementSet ms(setup_new_table);
 
     // Create the MS default subtables

--- a/src/pyms.cc
+++ b/src/pyms.cc
@@ -1,0 +1,189 @@
+#include <casacore/tables/Tables/TableProxy.h>
+
+#include <casacore/python/Converters/PycBasicData.h>
+#include <casacore/python/Converters/PycValueHolder.h>
+#include <casacore/python/Converters/PycRecord.h>
+
+#include <boost/python.hpp>
+#include <boost/python/args.hpp>
+
+#include <casacore/casa/Containers/RecordInterface.h>
+#include <casacore/tables/Tables/SetupNewTab.h>
+#include <casacore/ms/MeasurementSets/MeasurementSet.h>
+#include <casacore/tables/Tables/TableDesc.h>
+#include <casacore/tables/Tables/TableError.h>
+#include <casacore/tables/Tables/TableRecord.h>
+
+
+using namespace boost::python;
+
+namespace casacore {
+
+  Record required_ms_desc(const String & table)
+  {
+    String table_ = table;
+
+    // Upper case things to be sure
+    table_.upcase();
+
+    if(table_.empty() || table_ == "MAIN")
+    {
+      return TableProxy::getTableDesc(MeasurementSet::requiredTableDesc(), true);
+    }
+    else if(table_ == "ANTENNA")
+    {
+      return TableProxy::getTableDesc(MSAntenna::requiredTableDesc(), true);
+    }
+    else if(table_ == "DATA_DESCRIPTION")
+    {
+      return TableProxy::getTableDesc(MSDataDescription::requiredTableDesc(), true);
+    }
+    else if(table_ == "DOPPLER")
+    {
+      return TableProxy::getTableDesc(MSDoppler::requiredTableDesc(), true);
+    }
+    else if(table_ == "FEED")
+    {
+      return TableProxy::getTableDesc(MSFeed::requiredTableDesc(), true);
+    }
+    else if(table_ == "FIELD")
+    {
+      return TableProxy::getTableDesc(MSField::requiredTableDesc(), true);
+    }
+    else if(table_ == "FLAG_CMD")
+    {
+      return TableProxy::getTableDesc(MSFlagCmd::requiredTableDesc(), true);
+    }
+    else if(table_ == "FREQ_OFFSET")
+    {
+      return TableProxy::getTableDesc(MSFreqOffset::requiredTableDesc(), true);
+    }
+    else if(table_ == "HISTORY")
+    {
+      return TableProxy::getTableDesc(MSHistory::requiredTableDesc(), true);
+    }
+    else if(table_ == "OBSERVATION")
+    {
+      return TableProxy::getTableDesc(MSObservation::requiredTableDesc(), true);
+    }
+    else if(table_ == "POINTING")
+    {
+      return TableProxy::getTableDesc(MSPointing::requiredTableDesc(), true);
+    }
+    else if(table_ == "POLARIZATION")
+    {
+      return TableProxy::getTableDesc(MSPolarization::requiredTableDesc(), true);
+    }
+    else if(table_ == "PROCESSOR")
+    {
+      return TableProxy::getTableDesc(MSProcessor::requiredTableDesc(), true);
+    }
+    else if(table_ == "SOURCE")
+    {
+      return TableProxy::getTableDesc(MSSource::requiredTableDesc(), true);
+    }
+    else if(table_ == "SPECTRAL_WINDOW")
+    {
+      return TableProxy::getTableDesc(MSSpectralWindow::requiredTableDesc(), true);
+    }
+    else if(table_ == "STATE")
+    {
+      return TableProxy::getTableDesc(MSState::requiredTableDesc(), true);
+    }
+    else if(table_ == "SYSCAL")
+    {
+      return TableProxy::getTableDesc(MSSysCal::requiredTableDesc(), true);
+    }
+    else if(table_ == "WEATHER")
+    {
+      return TableProxy::getTableDesc(MSWeather::requiredTableDesc(), true);
+    }
+
+    throw TableError("Unknown table type: " + table_);
+  }
+
+  TableProxy default_ms(const String & name, const Record & table_desc)
+  {
+    String msg;
+    TableDesc user_td;
+
+    // Create Table Description object from extra user table description
+    if(!TableProxy::makeTableDesc(table_desc, user_td, msg))
+    {
+      throw TableError("Error Making Table Description " + msg);
+    }
+
+    user_td.show(std::cout);
+
+
+    TableDesc required_td = MeasurementSet::requiredTableDesc();
+
+    // Overwrite required columns with user columns
+    for(uInt i=0; i < user_td.ncolumn(); ++i)
+    {
+      const String & name = user_td[i].name();
+
+      // Remove if present in required
+      if(required_td.isColumn(name))
+      {
+        required_td.removeColumn(name);
+      }
+
+      // Add the column
+      required_td.addColumn(user_td[i]);
+    }
+
+    // Overwrite required hypercolumns with user hypercolumns
+    // In practice this shouldn't be necessary as requiredTableDesc
+    // doesn't define hypercolumns by default...
+    Vector<String> user_hc = user_td.hypercolumnNames();
+
+    for(uInt i=0; i < user_hc.size(); ++i)
+    {
+      // Remove if hypercolumn is present
+      if(required_td.isHypercolumn(user_hc[i]))
+      {
+        required_td.removeHypercolumnDesc(user_hc[i]);
+      }
+
+      Vector<String> dataColumnNames;
+      Vector<String> coordColumnNames;
+      Vector<String> idColumnNames;
+
+      // Get the user hypercolumn
+      uInt ndims = user_td.hypercolumnDesc(user_hc[i],
+          dataColumnNames, coordColumnNames, idColumnNames);
+      // Place it in required_td
+      required_td.defineHypercolumn(user_hc[i], ndims,
+          dataColumnNames, coordColumnNames, idColumnNames);
+    }
+
+    // Overwrite required keywords with user keywords
+    required_td.rwKeywordSet().merge(user_td.keywordSet(),
+      RecordInterface::OverwriteDuplicates);
+
+    required_td.show(std::cout);
+
+    // Setup table definition
+    SetupNewTable new_table(name, required_td, Table::New);
+
+    // Create the MS
+    MeasurementSet ms(new_table);
+
+    // Create the default subtables
+    ms.createDefaultSubtables(Table::New);
+
+    // Create a table proxy
+    return TableProxy(ms);
+  }
+
+namespace python {
+
+  void pyms()
+  {
+    def("_default_ms", &default_ms, (boost::python::arg("name")));
+    def("_required_ms_desc", &required_ms_desc, (boost::python::arg("column")));
+  }
+
+}
+}

--- a/src/pyms.cc
+++ b/src/pyms.cc
@@ -31,7 +31,27 @@ namespace casacore {
     table_.upcase();
 
     if(table_.empty() || table_ == "MAIN") {
-      return MeasurementSet::requiredTableDesc();
+      TableDesc tabdesc = MeasurementSet::requiredTableDesc();
+
+      // Remove the CATEGORY keyword from the FLAG_CATEGORY column
+      // This empty Vector<String> gets converted to a python dictionary as
+      // 'FLAG_CATEGORY' : {
+      //     ...
+      //     keywords': {'CATEGORY' : []},
+      //     ...
+      // }
+      //
+      // Due to the missing type information this gets converted
+      // into something like Vector<int> when passed to the C++ layer,
+      // which results in Table Conformance errors
+      // This is an OK solution since the C++ layer always adds this keyword
+      // if it is missing from the MS
+      // (see addCat())
+
+      tabdesc.rwColumnDesc("FLAG_CATEGORY")
+             .rwKeywordSet().removeField("CATEGORY");
+
+      return tabdesc;
     } else if(table_ == "ANTENNA") {
       return MSAntenna::requiredTableDesc();
     } else if(table_ == "DATA_DESCRIPTION") {

--- a/src/pytable.cc
+++ b/src/pytable.cc
@@ -277,5 +277,5 @@ namespace casacore { namespace python {
       .def ("_getcalcresult", &TableProxy::getCalcResult)
       ;
   }
-    
+
 }}

--- a/src/tables.cc
+++ b/src/tables.cc
@@ -48,5 +48,7 @@ BOOST_PYTHON_MODULE(_tables)
   casa::python::pytablerow();
   casa::python::pytableiter();
   casa::python::pytableindex();
+
+  casa::python::pyms();
 }
 

--- a/src/tables.h
+++ b/src/tables.h
@@ -38,6 +38,8 @@ namespace casacore {
     void pytableiter();
     void pytableindex();
 
+    void pyms();
+
   } // python
 } //casa
 


### PR DESCRIPTION
Added three methods for creating canonical MeasurementSets and their subtables.
- `pyrap.tables.default_ms(name, tabdesc)`. This creates an MS called 'name' and associated subtables. Extra columns, hypercolumns and keywords can be specified in tabdesc which will overwrite/merge into the standard definition for the MS.
- `pyrap.tables.default_ms_subtable(subtable, tabdesc)`. This creates an MS subtable. For e.g. `default_ms_subtable("ANTENNA")` will created an ANTENNA subtable. Extra columns, hypercolumns and keywords can be specified in tabdesc which will overwrite/merge into the standard definition for the subtable.
- `pyrap.tables.msutils.required_ms_desc(table)`. Returns a dictionary table description for the specified table. `required_ms_desc("MAIN")` will return a description for a Measurement Set, while `required_ms_desc("ANTENNA")` will return a description for the ANTENNA subtable.