### PR TITLE
Replace deprecated - by numpy.logical_not

### DIFF
--- a/casacore/images/image.py
+++ b/casacore/images/image.py
@@ -319,9 +319,9 @@ class image(Image):
         set to False.
 
         """
-        return -self._getmask(self._adjustBlc(blc),
-                              self._adjustTrc(trc),
-                              self._adjustInc(inc))
+        return numpy.logical_not(self._getmask(self._adjustBlc(blc),
+                                               self._adjustTrc(trc),
+                                               self._adjustInc(inc)))
 
     # Get data and mask
     def get(self, blc=(), trc=(), inc=()):


### PR DESCRIPTION
The use of `-` was deprecated for some time. Apparently conda now installs a numpy which doesn't tolerate a `-` for negating an array anymore.