### PR TITLE
Added osx-travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,37 @@
 language: python
 sudo: required
 dist: trusty
-python:
- - 2.7
- - 3.5
- - 3.6
-os:
- - linux
- # - osx
+
+matrix:
+    include:
+        - os: linux
+          python: "2.7"
+
+        - os: linux
+          python: "3.5"
+
+        - os: linux
+          python: "3.6"
+
+        # Use generic language for osx
+        - os: osx
+          language: generic
+          python: "2.7"
+          env: TRAVIS_PYTHON_VERSION=2.7
+
+        - os: osx
+          language: generic
+          python: "3.5"
+          env: TRAVIS_PYTHON_VERSION=3.5
+
+        - os: osx
+          language: generic
+          python: "3.6"
+          env: TRAVIS_PYTHON_VERSION=3.6
+
+    allow_failures:
+    - os: osx
+
 
 before_install:
  - .travis/before_install.sh
@@ -40,4 +64,3 @@ notifications:
   webhooks:
    urls:
     - https://webhooks.gitter.im/e/08a570c12a3afa37d8e2
-

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 
 # Inspired by https://conda.io/docs/travis.html
+env
+
 set -e
 set -v
+
 
 if [ "$TRAVIS_OS_NAME" = linux ]; then
     sudo apt-get update
     MINICONDAVERSION="Linux"
 else
     MINICONDAVERSION="MacOSX"
+    brew update;
 fi
 
 if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
@@ -25,7 +29,6 @@ conda update -q conda
 conda config --add channels conda-forge
 # Useful for debugging any issues with conda
 conda info -a
-
 conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION casacore=2.3.0
 
 echo "measures.directory: /home/travis/data" > $HOME/.casarc

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
 # Inspired by https://conda.io/docs/travis.html
-env
-
 set -e
 set -v
 
@@ -12,14 +10,13 @@ if [ "$TRAVIS_OS_NAME" = linux ]; then
     MINICONDAVERSION="Linux"
 else
     MINICONDAVERSION="MacOSX"
-    brew update;
 fi
 
 if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
   wget https://repo.continuum.io/miniconda/Miniconda2-latest-$MINICONDAVERSION-x86_64.sh -O miniconda.sh;
 else
   wget https://repo.continuum.io/miniconda/Miniconda3-latest-$MINICONDAVERSION-x86_64.sh -O miniconda.sh;
-  fi
+fi
 
 bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
@@ -31,4 +28,4 @@ conda config --add channels conda-forge
 conda info -a
 conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION casacore=2.3.0
 
-echo "measures.directory: /home/travis/data" > $HOME/.casarc
+echo "measures.directory: $HOME/data" > $HOME/.casarc


### PR DESCRIPTION
Python builds are not yet available on the OS X environment natively(https://github.com/travis-ci/travis-ci/issues/2312). Miniconda fixed the environment issue, but still python-casacore is having problem with data packages on osx environment on Travis.