### PR TITLE
Avoiding TypeError deep down in setuptool

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -173,6 +173,8 @@ def get_extensions():
                 if found_lib:
                     depends = depends + [found_lib]
 
+        # None libraries can cause errors deep down
+        libraries = list(filter(None, libraries))
         extensions.append(Extension(name=name, sources=sources, depends=depends,
                                     libraries=libraries))
     return extensions

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,8 @@ def find_boost():
     for libboostname in boostlibnames:
         if find_library_file(libboostname):
             return libboostname
-    return None
+    warnings.warn(no_boost_error)
+    return boostlibnames[0]
 
 
 def find_casacore():
@@ -102,19 +103,15 @@ def find_casacore():
             if LooseVersion(casacoreversion.decode()) < LooseVersion(__mincasacoreversion__):
                 warnings.warn("Your casacore version is too old. Minimum is " + __mincasacoreversion__)
 
-    if find_library_file(casa_python):
-        return casa_python
-    return None
+    if not find_library_file(casa_python):
+        warnings.warn(no_casacore_error)
+    return casa_python
 
 
 def get_extensions():
-    boost_python = find_boost()
-    if not boost_python:
-        warnings.warn(no_boost_error)
 
+    boost_python = find_boost()
     casa_python = find_casacore()
-    if not casa_python:
-        warnings.warn(no_casacore_error)
 
     extension_metas = (
         # name, sources, depends, libraries
@@ -173,8 +170,6 @@ def get_extensions():
                 if found_lib:
                     depends = depends + [found_lib]
 
-        # None libraries can cause errors deep down
-        libraries = list(filter(None, libraries))
         extensions.append(Extension(name=name, sources=sources, depends=depends,
                                     libraries=libraries))
     return extensions


### PR DESCRIPTION
While compiling the python-casacore modules the compilation failed with:

```
[...]
line 199, in build_extension
    _build_ext.build_extension(self, ext)
  File "/usr/lib/python3.6/distutils/command/build_ext.py", line 558, in build_extension
    target_lang=language)
  File "/usr/lib/python3.6/distutils/ccompiler.py", line 717, in link_shared_object
    extra_preargs, extra_postargs, build_temp, target_lang)
  File "/usr/lib/python3.6/distutils/unixccompiler.py", line 170, in link
    libraries)
  File "/usr/lib/python3.6/distutils/ccompiler.py", line 1105, in gen_lib_options
    (lib_dir, lib_name) = os.path.split(lib)
  File "/usr/lib/python3.6/posixpath.py", line 107, in split
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

This is because my casacore installation is in a non-standard directory. This happened at link time; however at compilation time the issue was not present, as I had already adjusted my `setup.cfg` accordingly. This issue instead was caused by the fact that looking for boost and casacore is done only using the `-L` command-line parameter, but the program continues anyway if they are not found.

The current logic only warns users about missing libraries, but still passed down those `None` values down to setuptools as part of the `libraries` `Extension` argument, which triggered failures when linking the generated modules.

In the solution I'm using `filter` + `list` because Extension's libraries argument is defined as ["a list of strings"](https://docs.python.org/3/distutils/apiref.html#distutils.core.Extension), but filter returns an iterator in py3.

cc: @JasonRuonanWang @gervandiepen