### PR TITLE
Correct header guard macro definition

### DIFF
--- a/src/pymeasures.h
+++ b/src/pymeasures.h
@@ -26,7 +26,7 @@
 //# $Id: pymeasures.h,v 1.1 2006/09/28 05:55:00 mmarquar Exp $
 
 #ifndef PYRAP_MEASURES_H
-#define PYRAP_PYMEASURES_H
+#define PYRAP_MEASURES_H
 
 #include <casacore/casa/aips.h>
 


### PR DESCRIPTION
The name of the macros used for guarding the header inclusion did not
correspond to each other, and therefore including the file multiple
times within a single compilation unit would have led to errors. I chose
the macro name without the _PY prefix because that aligns better with
what can be found in the rest of the headers under src/.