### PR TITLE
Make derivedmscal and meas functions known at start

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ def get_extensions():
             ["src/pytable.cc", "src/pytableindex.cc", "src/pytableiter.cc",
              "src/pytablerow.cc", "src/tables.cc", "src/pyms.cc"],
             ["src/tables.h"],
-            ['casa_tables', 'casa_ms', boost_python, casa_python],
+            ['casa_derivedmscal', 'casa_meas', 'casa_ms', 'casa_tables', boost_python, casa_python],
         ),
         (
             "casacore._tConvert",

--- a/src/tables.cc
+++ b/src/tables.cc
@@ -34,6 +34,9 @@
 #include <casacore/python/Converters/PycArray.h>
 #include <casacore/tables/Tables/TableProxy.h>
 
+#include <casacore/meas/MeasUDF/Register.h>
+#include <casacore/derivedmscal/DerivedMC/Register.h>
+
 #include <boost/python.hpp>
 
 BOOST_PYTHON_MODULE(_tables)
@@ -50,5 +53,11 @@ BOOST_PYTHON_MODULE(_tables)
   casacore::python::pytableindex();
 
   casacore::python::pyms();
+
+  // Register the TaQL meas and mscal functions.
+  // Normally they are loaded as a shared library, but that cannot
+  // be done if the program is built statically.
+  register_meas();
+  register_derivedmscal();
 }
 


### PR DESCRIPTION
This change links TaQL's mscal and meas functions into the _tables module, so these functions can be used when a static library is built.
