### PR TITLE
Use ~ instead of - to negate the mask

### DIFF
--- a/casacore/images/image.py
+++ b/casacore/images/image.py
@@ -92,7 +92,11 @@ class image(Image):
       | An optional mask to be stored in the image when creating the image.
         If a mask is given, but no maskname is given, the mask will get the
         name `mask0`.
-      | Note that the mask can also be given in argument `values` (see above).
+      | The mask can also be given in argument `values` (see above).
+      | Note that the casacore images use the convention that a mask value
+        True means good and False means bad. However, numpy uses the opposite.
+        Therefore the mask will be negated, so a numpy masked can be given
+        directly.
     `shape`
       If given, the image will be created. If `values` is also given, its
       shape should match. If `values` is not given, an image with data type
@@ -162,7 +166,7 @@ class image(Image):
                                 mask = nma.getmaskarray(values)
                             values = values.data
                         if len(mask) > 0:
-                            mask = -mask  # casa and numpy have opposite flags
+                            mask = ~mask  # casa and numpy have opposite flags
                         Image.__init__(self, values, mask, coord,
                                        imagename, overwrite, ashdf5,
                                        maskname, tileshape)
@@ -355,7 +359,7 @@ class image(Image):
         as the dimensionality of the image.
         Note that the casacore images use the convention that a mask value
         True means good and False means bad. However, numpy uses the opposite.
-        Therefore the mask will be negated, so a numoy masked can be given
+        Therefore the mask will be negated, so a numpy masked can be given
         directly.
 
         The mask is not written if the image has no mask and if it the entire

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -52,11 +52,11 @@ class TestImage(unittest.TestCase):
     def test_image_mask(self):
         """Test image mask."""
         im1 = image("testimg", shape=[2, 3])
-        im1.put(nma.masked_array(numpy.array([[1, 2, 3], [4, 5, 6]]),
-                mask=[[False, True, False], [False, False, True]]))
-        numpy.testing.assert_equal(im1.getmask(),
-                                   numpy.array([[False, True, False],
-                                               [False, False, True]]))
+        marr = nma.masked_array(numpy.array([[1, 2, 3], [4, 5, 6]]),
+                mask=[[False, True, False], [False, False, True]])
+        im1.put(marr)
+        numpy.testing.assert_equal(im1.getdata(), marr.data)
+        numpy.testing.assert_equal(im1.getmask(), marr.mask)
         im1.putmask(numpy.array([[True, False, True],
                                 [False, False, False]]), (0, 0), (0, 1))
         numpy.testing.assert_equal(im1.getmask(),
@@ -67,6 +67,14 @@ class TestImage(unittest.TestCase):
         im1.putdata(numpy.array([0, 1, 0]), (0, 0), (0, 1))
         numpy.testing.assert_equal(im1.getdata(),
                                    numpy.array([[0, 1, 0], [4, 5, 6]]))
+
+    def test_image_mask2(self):
+        """Test image mask."""
+        marr = nma.masked_array(numpy.array([[1., 2, 3], [4, 5, 6]]),
+                mask=[[False, True, False], [False, False, True]])
+        im1 = image("testimg", values=marr)
+        numpy.testing.assert_equal(im1.getdata(), marr.data)
+        numpy.testing.assert_equal(im1.getmask(), marr.mask)
 
     def test_lock(self):
         """Test lock."""


### PR DESCRIPTION
Accidently an incorrect operator was used to negate the mask in the image constructor.
It has been fixed. The documentation has been improved.
