### PR TITLE
Expose complete MS and subtable definitions

### DIFF
--- a/casacore/tables/msutil.py
+++ b/casacore/tables/msutil.py
@@ -26,9 +26,11 @@
 from six import string_types
 import numpy as np
 import six
-from casacore.tables.table import table, taql, _required_ms_desc
-from casacore.tables.tableutil import makescacoldesc, makearrcoldesc, \
-    makecoldesc, maketabdesc
+from casacore.tables.table import (table, taql,
+                                   _required_ms_desc,
+                                   _complete_ms_desc)
+from casacore.tables.tableutil import (makescacoldesc, makearrcoldesc,
+                                       makecoldesc, maketabdesc)
 
 
 def required_ms_desc(table=None):
@@ -43,6 +45,20 @@ def required_ms_desc(table=None):
         table = ""
 
     return _required_ms_desc(table)
+
+
+def complete_ms_desc(table=None):
+    """
+    Obtain the complete table description for a given table.
+
+    If "" or "MAIN", the description for a MeasurementSet is returned.
+    Otherwise, a the description for a MeasurementSet subtable is returned.
+    """
+    # Default to MAIN table
+    if table is None:
+        table = ""
+
+    return _complete_ms_desc(table)
 
 
 def addImagingColumns(msname, ack=True):

--- a/casacore/tables/table.py
+++ b/casacore/tables/table.py
@@ -40,7 +40,8 @@ from six import string_types
 from ._tables import (Table,
                       _default_ms,
                       _default_ms_subtable,
-                      _required_ms_desc)
+                      _required_ms_desc,
+                      _complete_ms_desc)
 
 from .tablehelper import (_add_prefix, _remove_prefix, _do_remove_prefix,
                           _format_row)

--- a/casacore/tables/tableutil.py
+++ b/casacore/tables/tableutil.py
@@ -496,13 +496,15 @@ def makedminfo(tabdesc, group_spec=None):
     The table description
   `group_spec`
     The SPEC for a data manager group. In practice this is useful for
-    setting the Default Tile Size and Maximum Cache Size for the Data Manager
+    setting the Default Tile Size and Maximum Cache Size for the Data Manager::
+
       {
         'WeightColumnGroup' : {
           'DEFAULTTILESHAPE': np.int32([4,4,4]),
           'MAXIMUMCACHESIZE': 1000,
         }
       }
+
     This should be used with care.
 
   """

--- a/doc/casacore_tables.rst
+++ b/doc/casacore_tables.rst
@@ -6,6 +6,10 @@ Module :mod:`tables`
 
 Table utility functions
 -----------------------
+:func:`default_ms`
+  Create a default MS.
+:func:`default_ms_subtable`
+  Create a default MS subtable.
 :func:`taql` or `tablecommand()`
   Execute TaQL query command
 :func:`tablefromascii`
@@ -48,12 +52,17 @@ MeasurementSet utility functions
   Remove the DerivedMSCal virtual columns like PA1, HA1 from a MeasurementSet
 :func:`msconcat`
   Concatenate spectral windows in different MSs to a single MS (in a virtual way)
+:func:`required_ms_desc`
+  Obtained the table descriptor describing a basic MS or an MS subtable.
+:func:`complete_ms_desc`
+  Obtain the table descriptor describing a complete MS or MS subtable.
 
 Utility functions details
 -------------------------
 .. autofunction:: casacore.tables.taql
 .. autofunction:: casacore.tables.tablefromascii
 .. autofunction:: casacore.tables.maketabdesc
+.. autofunction:: casacore.tables.makedminfo
 .. autofunction:: casacore.tables.makescacoldesc
 .. autofunction:: casacore.tables.makearrcoldesc
 .. autofunction:: casacore.tables.makecoldesc

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -524,11 +524,15 @@ class TestTable(unittest.TestCase):
         tabledelete("mytable")
 
     def test_complete_desc(self):
-
-        for st in ("MAIN",) + subtables:
-            desc = complete_ms_desc(st)
+        """ Test complete table descriptions """
+        for i, name in enumerate(("MAIN",) + subtables):
+            desc = complete_ms_desc(name)
             assert isinstance(desc, dict)
             assert len(desc) > 0
+
+            with table("complete_desc_table_%s-%d.table" % (name, i),
+                       desc, ack=False, readonly=False) as T:
+                T.addrows(10)
 
     def test_required_desc(self):
         """Testing required_desc."""

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -524,10 +524,11 @@ class TestTable(unittest.TestCase):
         tabledelete("mytable")
 
     def test_complete_desc(self):
-        complete_ms_desc("MAIN")
 
-        for st in subtables:
-            complete_ms_desc(st)
+        for st in ("MAIN",) + subtables:
+            desc = complete_ms_desc(st)
+            assert isinstance(desc, dict)
+            assert len(desc) > 0
 
     def test_required_desc(self):
         """Testing required_desc."""

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,9 +1,13 @@
 """Tests for tables module."""
 import unittest
-from casacore.tables import (makescacoldesc, makearrcoldesc, table, maketabdesc, tableexists, tableiswritable,
-                             tableinfo, tablefromascii, tabledelete, makecoldesc, msconcat, removeDerivedMSCal,
-                             taql, tablerename, tablecopy, tablecolumn, addDerivedMSCal, removeImagingColumns,
-                             addImagingColumns, complete_ms_desc, required_ms_desc, tabledefinehypercolumn,
+from casacore.tables import (makescacoldesc, makearrcoldesc, table,
+                             maketabdesc, tableexists, tableiswritable,
+                             tableinfo, tablefromascii, tabledelete,
+                             makecoldesc, msconcat, removeDerivedMSCal,
+                             taql, tablerename, tablecopy, tablecolumn,
+                             addDerivedMSCal, removeImagingColumns,
+                             addImagingColumns, complete_ms_desc,
+                             required_ms_desc, tabledefinehypercolumn,
                              default_ms, default_ms_subtable, makedminfo)
 import numpy as np
 import collections

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -3,10 +3,17 @@ import unittest
 from casacore.tables import (makescacoldesc, makearrcoldesc, table, maketabdesc, tableexists, tableiswritable,
                              tableinfo, tablefromascii, tabledelete, makecoldesc, msconcat, removeDerivedMSCal,
                              taql, tablerename, tablecopy, tablecolumn, addDerivedMSCal, removeImagingColumns,
-                             addImagingColumns, required_ms_desc, tabledefinehypercolumn, default_ms, makedminfo,
-                             default_ms_subtable)
+                             addImagingColumns, complete_ms_desc, required_ms_desc, tabledefinehypercolumn,
+                             default_ms, default_ms_subtable, makedminfo)
 import numpy as np
 import collections
+
+
+subtables = ("ANTENNA", "DATA_DESCRIPTION", "DOPPLER",
+             "FEED", "FIELD", "FLAG_CMD", "FREQ_OFFSET",
+             "HISTORY", "OBSERVATION", "POINTING", "POLARIZATION",
+             "PROCESSOR", "SOURCE", "SPECTRAL_WINDOW", "STATE",
+             "SYSCAL", "WEATHER")
 
 
 def compare(x, y):
@@ -512,6 +519,12 @@ class TestTable(unittest.TestCase):
         tab.done()
         tabledelete("mytable")
 
+    def test_complete_desc(self):
+        complete_ms_desc("MAIN")
+
+        for st in subtables:
+            complete_ms_desc(st)
+
     def test_required_desc(self):
         """Testing required_desc."""
         # =============================================
@@ -599,11 +612,6 @@ class TestTable(unittest.TestCase):
         # TEST 3
         # Test subtable creation
         # =============================================
-        subtables = ("ANTENNA", "DATA_DESCRIPTION", "DOPPLER",
-                     "FEED", "FIELD", "FLAG_CMD", "FREQ_OFFSET",
-                     "HISTORY", "OBSERVATION", "POINTING", "POLARIZATION",
-                     "PROCESSOR", "SOURCE", "SPECTRAL_WINDOW", "STATE",
-                     "SYSCAL", "WEATHER")
 
         for c in subtables:
             # Check that we can get the default description for this table


### PR DESCRIPTION
Required MS and subtable column + keywords definitions are exposed in `pyrap.tables.require_ms_desc`.

This PR exposes all optional column + keywords definitions in `pyrap.tables.complete_ms_desc`