### PR TITLE
Give error when casacore is too old

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ matrix:
   - env: TARGET=py3_casacore_v3.2
   - env: TARGET=py2_casacore_master
   - env: TARGET=py3_casacore_master
-  - env: TARGET=py2
-  - env: TARGET=py3
+  - env: TARGET=py2-kern
+  - env: TARGET=py3-kern
   - env: TARGET=pep8
   - env: TARGET=mypy
   allow_failures:
-  - env: TARGET=py2
-  - env: TARGET=py3
+  - env: TARGET=py2-kern
+  - env: TARGET=py3-kern
   - env: TARGET=pep8
   - env: TARGET=mypy
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
-matrix:
+os: linux
+dist: xenial
+jobs:
   include:
   - env: TARGET=py2_casacore_v3.2
   - env: TARGET=py3_casacore_v3.2
@@ -14,7 +16,6 @@ matrix:
   - env: TARGET=py3-kern
   - env: TARGET=pep8
   - env: TARGET=mypy
-sudo: required
 services:
  - docker
 before_install:
@@ -25,7 +26,7 @@ script:
  - .travis/script.sh
 deploy:
  provider: pypi
- user: gijzelaerr
+ username: gijzelaerr
  password:
   secure: cdrrma3XaFjtv4lHvag6dfhSbKBF8iLmVgPQEjXP8qa+WxHnkHObkyraYAFGqThDY/0lBdrBm7Og6l1JfAcSA2BjdPQYxujP8KEoVicPwlgwEJ5LZo4HqympWVk33APvbcYNw7K/CwEXNJCCD1tDiO4pdwkPAWuKlnYUVfZq2yI=
  skip_existing: true

--- a/.travis/py2-kern.docker
+++ b/.travis/py2-kern.docker
@@ -1,4 +1,4 @@
-FROM kernsuite/base:4
+FROM kernsuite/base:5
 RUN docker-apt-install \
     casacore-data \
     casacore-dev \

--- a/.travis/py3-kern.docker
+++ b/.travis/py3-kern.docker
@@ -1,4 +1,4 @@
-FROM kernsuite/base:4
+FROM kernsuite/base:5
 RUN docker-apt-install \
     casacore-data \
     casacore-dev \

--- a/.travis/py3_casacore_master.docker
+++ b/.travis/py3_casacore_master.docker
@@ -16,3 +16,4 @@ WORKDIR /code
 RUN pip3 install -e .
 RUN pip3 install -r tests/requirements.txt
 RUN nosetests3 --with-coverage --verbose --cover-package=casacore
+RUN python3 setup.py clean

--- a/casacore/__init__.py
+++ b/casacore/__init__.py
@@ -1,2 +1,2 @@
 __version__ = "3.2.0"
-__mincasacoreversion__ = "2.3.0"
+__mincasacoreversion__ = "3.1.1"

--- a/setup.py
+++ b/setup.py
@@ -128,10 +128,11 @@ def find_casacore():
             casacoreversion = getCasacoreVersion()
         except:
             # getVersion was fixed in casacore 2.3.0
-            warnings.warn("Your casacore version is older than 2.3.0! You need to upgrade your casacore.")
+            raise RuntimeError("Your casacore version is older than 2.3.0! You need to upgrade your casacore.")
         else:
             if LooseVersion(casacoreversion.decode()) < LooseVersion(__mincasacoreversion__):
-                warnings.warn("Your casacore version is too old. Minimum is " + __mincasacoreversion__)
+                raise RuntimeError("Your casacore version is too old. Minimum is " + __mincasacoreversion__ +
+                                   ", you have " + casacoreversion.decode('utf-8'))
 
         libdir = dirname(libcasacasa)
         includedir = join(dirname(libdir), "include")

--- a/setup.py
+++ b/setup.py
@@ -128,11 +128,11 @@ def find_casacore():
             casacoreversion = getCasacoreVersion()
         except:
             # getVersion was fixed in casacore 2.3.0
-            raise RuntimeError("Your casacore version is older than 2.3.0! You need to upgrade your casacore.")
+            warnings.warn("Your casacore version is older than 2.3.0! You need to upgrade your casacore.")
         else:
             if LooseVersion(casacoreversion.decode()) < LooseVersion(__mincasacoreversion__):
-                raise RuntimeError("Your casacore version is too old. Minimum is " + __mincasacoreversion__ +
-                                   ", you have " + casacoreversion.decode('utf-8'))
+                warnings.warn("Your casacore version is too old. Minimum is " + __mincasacoreversion__ +
+                              ", you have " + casacoreversion.decode('utf-8'))
 
         libdir = dirname(libcasacasa)
         includedir = join(dirname(libdir), "include")


### PR DESCRIPTION
The travis tests using KERN all fail on a unicode error. Probably this was fixed in casacore 3.1.1, which has unicode improvements. I'll bump to KERN5 to see if it helps, but KERN5 has casacore ~2.5.0~ 3.0.0, so probably not.