### PR TITLE
Fix of result of tablecolumn.len

### DIFF
--- a/casacore/tables/table.py
+++ b/casacore/tables/table.py
@@ -418,7 +418,7 @@ class table(Table):
 
     def __len__(self):
         """Return the number of rows in the table."""
-        return self._nrows()
+        return int(self._nrows())
 
     def __getattr__(self, name):
         """Get the tablecolumn object or keyword value.
@@ -882,7 +882,7 @@ class table(Table):
 
     def nrows(self):
         """Return the number of rows in the table."""
-        return self._nrows()
+        return int(self._nrows())
 
     def addrows(self, nrows=1):
         """Add one or more rows to the table."""


### PR DESCRIPTION
Since the change to 64-bit row numbers, casacore returns an Int64 for nr of rows. Boost-python turns that into a long (e.g. 10L) in python. It appears that python's len function expects an int, so table.py changes the result into an int.
