### PR TITLE
Hardcode data path to that used in KERN / ubuntu

### DIFF
--- a/manylinux2010/wheel27.docker
+++ b/manylinux2010/wheel27.docker
@@ -64,7 +64,7 @@ RUN cmake .. \
     -DPYTHON2_EXECUTABLE=/opt/python/${TARGET}/bin/python \
     -DPYTHON_INCLUDE_DIR=/opt/python/${TARGET}/include/python${PYMAJOR}.${PYMINOR}/ \
     -DBUILD_TESTING=OFF \
-    -DDATA_DIR=/build \
+    -DDATA_DIR=/usr/share/casacore/data \
     -DBUILD_PYTHON3=OFF \
     -DCMAKE_INSTALL_PREFIX=/usr/local \
     -DBOOST_ROOT=/opt/boost \

--- a/manylinux2010/wheel34.docker
+++ b/manylinux2010/wheel34.docker
@@ -65,7 +65,7 @@ RUN cmake .. \
     -DPYTHON3_EXECUTABLE=/opt/python/${TARGET}/bin/python \
     -DPYTHON_INCLUDE_DIR=/opt/python/${TARGET}/include/python${PYMAJOR}.${PYMINOR}m/ \
     -DBUILD_TESTING=OFF \
-    -DDATA_DIR=/build \
+    -DDATA_DIR=/usr/share/casacore/data \
     -DBUILD_PYTHON3=ON \
     -DBUILD_PYTHON=OFF \
     -DCMAKE_INSTALL_PREFIX=/usr/local \

--- a/manylinux2010/wheel35.docker
+++ b/manylinux2010/wheel35.docker
@@ -65,7 +65,7 @@ RUN cmake .. \
     -DPYTHON3_EXECUTABLE=/opt/python/${TARGET}/bin/python \
     -DPYTHON_INCLUDE_DIR=/opt/python/${TARGET}/include/python${PYMAJOR}.${PYMINOR}m/ \
     -DBUILD_TESTING=OFF \
-    -DDATA_DIR=/build \
+    -DDATA_DIR=/usr/share/casacore/data \
     -DBUILD_PYTHON3=ON \
     -DBUILD_PYTHON=OFF \
     -DCMAKE_INSTALL_PREFIX=/usr/local \

--- a/manylinux2010/wheel36.docker
+++ b/manylinux2010/wheel36.docker
@@ -65,7 +65,7 @@ RUN cmake .. \
     -DPYTHON3_EXECUTABLE=/opt/python/${TARGET}/bin/python \
     -DPYTHON_INCLUDE_DIR=/opt/python/${TARGET}/include/python${PYMAJOR}.${PYMINOR}m/ \
     -DBUILD_TESTING=OFF \
-    -DDATA_DIR=/build \
+    -DDATA_DIR=/usr/share/casacore/data \
     -DBUILD_PYTHON3=ON \
     -DBUILD_PYTHON=OFF \
     -DCMAKE_INSTALL_PREFIX=/usr/local \

--- a/manylinux2010/wheel37.docker
+++ b/manylinux2010/wheel37.docker
@@ -65,7 +65,7 @@ RUN cmake .. \
     -DPYTHON3_EXECUTABLE=/opt/python/${TARGET}/bin/python \
     -DPYTHON_INCLUDE_DIR=/opt/python/${TARGET}/include/python${PYMAJOR}.${PYMINOR}m/ \
     -DBUILD_TESTING=OFF \
-    -DDATA_DIR=/build \
+    -DDATA_DIR=/usr/share/casacore/data \
     -DBUILD_PYTHON3=ON \
     -DBUILD_PYTHON=OFF \
     -DCMAKE_INSTALL_PREFIX=/usr/local \

--- a/manylinux2010/wheel38.docker
+++ b/manylinux2010/wheel38.docker
@@ -64,7 +64,7 @@ RUN cmake .. \
     -DPYTHON3_EXECUTABLE=/opt/python/${TARGET}/bin/python \
     -DPYTHON_INCLUDE_DIR=/opt/python/${TARGET}/include/python${PYMAJOR}.${PYMINOR}/ \
     -DBUILD_TESTING=OFF \
-    -DDATA_DIR=/build \
+    -DDATA_DIR=/usr/share/casacore/data \
     -DBUILD_PYTHON3=ON \
     -DBUILD_PYTHON=OFF \
     -DCMAKE_INSTALL_PREFIX=/usr/local \


### PR DESCRIPTION
Other data paths can still be used by putting this in ~/.casarc
measures.directory: /mypath/to/casacore/data

Fixes #181