### PR TITLE
Add code to drop the GIL. Demostrate usefulness on reads/writes.

### DIFF
--- a/src/guards.h
+++ b/src/guards.h
@@ -1,0 +1,115 @@
+#include <iostream>
+
+#include <boost/function.hpp>
+#include <boost/function_types/components.hpp>
+#include <boost/function_types/function_type.hpp>
+#include <boost/function_types/result_type.hpp>
+#include <boost/python.hpp>
+#include <boost/tuple/tuple.hpp>
+
+namespace details {
+
+/// @brief Functor that will invoke a function while holding a guard.
+///        Upon returning from the function, the guard is released.
+template <typename Signature,
+          typename Guard>
+class guarded_function
+{
+public:
+
+  typedef typename boost::function_types::result_type<Signature>::type
+      result_type;
+
+  template <typename Fn>
+  guarded_function(Fn fn)
+    : fn_(fn)
+  {}
+
+  template <typename... Args>
+  result_type operator()(Args... args)
+  {
+    Guard g;
+    return fn_(args...);
+  } 
+
+private:
+  boost::function<Signature> fn_;
+};
+
+/// @brief Provides signature type.
+template <typename Signature>
+struct mpl_signature
+{
+  typedef typename boost::function_types::components<Signature>::type type;
+};
+
+// Support boost::function.
+template <typename Signature>
+struct mpl_signature<boost::function<Signature> >:
+  public mpl_signature<Signature>
+{};
+
+/// @brief Create a callable object with guards.
+template <typename Guard,
+          typename Fn,
+          typename Policy>
+boost::python::object with_aux(Fn fn, const Policy& policy)
+{
+  // Obtain the components of the Fn.  This will decompose non-member
+  // and member functions into an mpl sequence.
+  //   R (*)(A1)    => R, A1
+  //   R (C::*)(A1) => R, C*, A1
+  typedef typename mpl_signature<Fn>::type mpl_signature_type;
+
+  // Synthesize the components into a function type.  This process
+  // causes member functions to require the instance argument.
+  // This is necessary because member functions will be explicitly
+  // provided the 'self' argument.
+  //   R, A1     => R (*)(A1)
+  //   R, C*, A1 => R (*)(C*, A1)
+  typedef typename boost::function_types::function_type<
+      mpl_signature_type>::type signature_type;
+
+  // Create a callable boost::python::object that delegates to the
+  // guarded_function.
+  return boost::python::make_function(
+    guarded_function<signature_type, Guard>(fn),
+    policy, mpl_signature_type());
+}
+
+} // namespace details
+
+/// @brief Create a callable object with guards.
+template <typename Guard,
+          typename Fn,
+          typename Policy>
+boost::python::object with(const Fn& fn, const Policy& policy)
+{
+  return details::with_aux<Guard>(fn, policy);
+}
+
+/// @brief Create a callable object with guards.
+template <typename Guard,
+          typename Fn>
+boost::python::object with(const Fn& fn)
+{
+  return with<Guard>(fn, boost::python::default_call_policies());
+}
+
+/// @brief Guard that will unlock the GIL upon construction, and
+///        reacquire it upon destruction.
+struct no_gil
+{
+public:
+  no_gil()  { state_ = PyEval_SaveThread(); }
+  ~no_gil() { PyEval_RestoreThread(state_); }
+private:
+  PyThreadState* state_;
+};
+
+/// @brief Guard that prints to std::cout.
+struct echo_guard 
+{
+  echo_guard()  { std::cout << "echo_guard()" << std::endl;  }
+  ~echo_guard() { std::cout << "~echo_guard()" << std::endl; }
+};

--- a/src/pytable.cc
+++ b/src/pytable.cc
@@ -33,6 +33,7 @@
 
 #include <boost/python.hpp>
 #include <boost/python/args.hpp>
+#include "guards.h"
 
 using namespace boost::python;
 
@@ -139,59 +140,15 @@ namespace casacore { namespace python {
       .def ("_iscelldefined", &TableProxy::cellContentsDefined,
 	    (boost::python::arg("columnname"),
 	     boost::python::arg("rownr")))
-      .def ("_getcell", &TableProxy::getCell,
-	    (boost::python::arg("columnname"),
-	     boost::python::arg("rownr")))
-      .def ("_getcellvh", &TableProxy::getCellVH,
-	    (boost::python::arg("columnname"),
-	     boost::python::arg("rownr"),
-             boost::python::arg("value")))
-      .def ("_getcellslice", &TableProxy::getCellSliceIP,
-	    (boost::python::arg("columnname"),
-	     boost::python::arg("rownr"),
-	     boost::python::arg("blc"),
-	     boost::python::arg("trc"),
-	     boost::python::arg("inc")))
-      .def ("_getcellslicevh", &TableProxy::getCellSliceVHIP,
-	    (boost::python::arg("columnname"),
-	     boost::python::arg("rownr"),
-	     boost::python::arg("blc"),
-	     boost::python::arg("trc"),
-	     boost::python::arg("inc"),
-             boost::python::arg("value")))
-      .def ("_getcol", &TableProxy::getColumn,
-	    (boost::python::arg("columnname"),
-	     boost::python::arg("startrow"),
-	     boost::python::arg("nrow"),
-	     boost::python::arg("rowincr")))
-      .def ("_getcolvh", &TableProxy::getColumnVH,
-	    (boost::python::arg("columnname"),
-	     boost::python::arg("startrow"),
-	     boost::python::arg("nrow"),
-	     boost::python::arg("rowincr"),
-             boost::python::arg("value")))
-      .def ("_getvarcol", &TableProxy::getVarColumn,
-	    (boost::python::arg("columnname"),
-	     boost::python::arg("startrow"),
-	     boost::python::arg("nrow"),
-	     boost::python::arg("rowincr")))
-      .def ("_getcolslice", &TableProxy::getColumnSliceIP,
-	    (boost::python::arg("columnname"),
-	     boost::python::arg("blc"),
-	     boost::python::arg("trc"),
-	     boost::python::arg("inc"),
-	     boost::python::arg("startrow"),
-	     boost::python::arg("nrow"),
-	     boost::python::arg("rowincr")))
-      .def ("_getcolslicevh", &TableProxy::getColumnSliceVHIP,
-	    (boost::python::arg("columnname"),
-	     boost::python::arg("blc"),
-	     boost::python::arg("trc"),
-	     boost::python::arg("inc"),
-	     boost::python::arg("startrow"),
-	     boost::python::arg("nrow"),
-	     boost::python::arg("rowincr"),
-             boost::python::arg("value")))
+      .def ("_getcell", with<no_gil>(&TableProxy::getCell))
+      .def ("_getcellvh", with<no_gil>(&TableProxy::getCellVH))
+      .def ("_getcellslice", with<no_gil>(&TableProxy::getCellSliceIP))
+      .def ("_getcellslicevh", with<no_gil>(&TableProxy::getCellSliceVHIP))
+      .def ("_getcol", with<no_gil>(&TableProxy::getColumn))
+      .def ("_getcolvh", with<no_gil>(&TableProxy::getColumnVH))
+      .def ("_getvarcol", with<no_gil>(&TableProxy::getVarColumn))
+      .def ("_getcolslice", with<no_gil>(&TableProxy::getColumnSliceIP))
+      .def ("_getcolslicevh", with<no_gil>(&TableProxy::getColumnSliceVHIP))
       .def ("_putcell", &TableProxy::putCell,
 	    (boost::python::arg("columnname"),
 	     boost::python::arg("rownr"),


### PR DESCRIPTION
This is part of ongoing experiments to show the need for parallel reads (and possibly writes) when using measurement sets. This PR is a draft and should not be merged - its purpose is to demonstrate a proof of concept and to encourage discussion. The following [issue on casacore](https://github.com/casacore/casacore/issues/1038) is related.

### Motivation
Instruments such as MeerKAT and LOFAR produce huge quantities of data. Currently, limitations of the casacore table system prevent reading/writing from multiple threads. As algorithms and implementations become more massively parallel (the direction in which most development is heading), this limitation (particularly for reads) becomes a nasty bottleneck. 

### Alternatives
- Processes: Reading from multiple processes is already supported. However, multiprocessing is inherently more expensive and more complicated than multithreading. Personal experience has led me to believe that it is best avoided.
- Multi-MS: A multi-MS, by virtue of being several separate measurement sets on disk, allows us to side-step some of the problems with parallel reads. This will be discussed in more detail in a subsequent section.

### Problems
- GIL (Global Interpreter Lock): Currently, python-casacore does not drop the GIL. This means that any and all read/write operations will be serialized (when not using multiprocessing). This PR aims to demonstrate the value of dropping the GIL.
- Thread-safety: [Issues in casacore](https://github.com/casacore/casacore/issues/1038) lead to problems with thread safety which ultimately result in segfaults when attempting to read a single measurement set from multiple threads.

### Dropping the GIL
This PR adds the `guards.h` file. This, plus a small modification to `pytable.cc`, allows python-casacore to drop the GIL on reads. This code was adapted from [the following Stack Overflow](https://stackoverflow.com/questions/18618333/boost-python-wrap-functions-to-release-the-gil). Note that I am not a C++ developer so I might not know all the consequences of a change like this. The value of this will be demonstrated shortly.

### Experiment 1
The first experiment involves reading a single, conventional MS using a single thread, multiple threads and multiple processes both with and without the GIL. The code for this experiment is as follows:
<details><summary> Code for Experiment 1</summary>
<p>

```python
import pyrap.tables as pt
import numpy as np
from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, wait
import time


def get_data(ms_name, colname, startrow, nrow):

    ms = pt.table(ms_name, lockoptions="autonoread", ack=False)

    ref_row = ms.getcol(colname, nrow=1)
    ref_dims = ref_row.shape[1:]
    ref_dtype = ref_row.dtype
    
    out = np.empty((nrow, *ref_dims), dtype=ref_dtype)

    ms.getcolnp(colname, out, startrow=startrow, nrow=nrow)

    ms.close()

    return


if __name__ == "__main__":

    ms_name = "/path/to/ms"
    column = "DATA"

    ms = pt.table(ms_name, lockoptions="autonoread", ack=False)

    scan_ids, scan_counts = np.unique(ms.getcol("SCAN_NUMBER"), return_counts=True)

    startrows = [0]
    startrows.extend(np.cumsum(scan_counts))
    numrows = scan_counts

    inds = list(zip(startrows, numrows))

    ms.close()

    t0 = time.time()
    with ProcessPoolExecutor(max_workers=len(startrows)) as executor:
        futures = [executor.submit(get_data, ms_name, column, sr, nr)
                   for sr, nr in inds]
        wait(futures)
    print("Reading MS using processes: {:.3f}s".format(time.time() - t0))

    t0 = time.time()
    with ThreadPoolExecutor(max_workers=len(startrows)) as executor:
        futures = [executor.submit(get_data, ms_name, column, sr, nr)
                   for sr, nr in inds]
        wait(futures)
    print("Reading MS using threads: {:.3f}s".format(time.time() - t0))

    t0 = time.time()
    get_data(ms_name, column, 0, sum(numrows))
    print("Reading MS using a single thread: {:.3f}s".format(time.time() - t0))
```

</p>
</details>

The results of this experiment with casacore 3.3.1 (the GIL is not released):
```
Reading MS using processes: 4.712s
Reading MS using threads: 41.956s
Reading MS using a single thread: 42.183s
```

The results of this experiment with this PR (the GIL is released):
```
Reading MS using processes: 4.275s
Segmentation fault (core dumped)
```

This segmentation fault is not python-casacore's fault - this is the thread-safety issue alluded to above. Ideally this will be fixed upstream. This does however reveal behaviour which I believe is undesirable: python-casacore should not be relying on the GIL to ensure thread safety in the underlying casacore routines. 

### Experiment 2
The second experiment involves reading a multi-MS (split by scan into 12 sub-measurement sets) using a single thread, multiple threads and multiple processes both with and without the GIL. The code for this experiment is as follows:

<details><summary> Code for Experiment 2</summary>
<p>

```python
import pyrap.tables as pt
import numpy as np
from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, wait
import time


def get_data(ms_name, colname):

    ms = pt.table(ms_name, lockoptions="autonoread", ack=False)
    ms.setmaxcachesize(colname, 1)

    ref_row = ms.getcol(colname, nrow=1)
    ref_dims = ref_row.shape[1:]
    ref_dtype = ref_row.dtype

    out = np.empty((ms.nrows(), *ref_dims), dtype=ref_dtype)

    ms.getcolnp(colname, out)

    ms.close()

    return True


if __name__ == "__main__":

    ms_name = "/path/to/mms"
    column = "DATA"

    ms = pt.table(ms_name, lockoptions="autonoread", ack=False)

    subms_names = list(ms.partnames())
    n_subms = len(subms_names)

    ms.close()

    t0 = time.time()
    with ProcessPoolExecutor(max_workers=n_subms) as executor:
        futures = [executor.submit(get_data, subms_name, column)
                   for subms_name in subms_names]
        wait(futures)
    print("Reading multi-MS using processes: {:.3f}s".format(time.time() - t0))

    t0 = time.time()
    with ThreadPoolExecutor(max_workers=n_subms) as executor:
        futures = [executor.submit(get_data, subms_name, column)
                   for subms_name in subms_names]
        wait(futures)
    print("Reading multi-MS using threads: {:.3f}s".format(time.time() - t0))

    t0 = time.time()
    get_data(ms_name, column)
    print("Reading multi-MS using a single thread: {:.3f}s".format(time.time() - t0))
```

</p>
</details>

The results of this experiment with casacore 3.3.1 (the GIL is not released):
```
Reading multi-MS using processes: 4.537s
Reading multi-MS using threads: 43.657s
Reading multi-MS using a single thread: 45.974s
```

The results of this experiment with this PR (the GIL is released):
```
Reading multi-MS using processes: 4.601s
Reading multi-MS using threads: 4.685s
Reading multi-MS using a single thread: 47.493s
```

This experiment shows the value and potential of releasing the GIL in python-casacore, as the multi-MS was successfully read from multiple threads in a similar amount of time as using processes.

### Conclusions
I believe this PR demonstrates both the value and danger of releasing the GIL in the python-casacore layer. Having the ability to read from multiple threads can massively accelerate parallel processing as shown in experiment 2. At the same time, experiment 1 exposes thread-safety issues in the underlying casacore routines. I believe that the ultimate solution is to drop the GIL and fix the cause of the segmentation faults in casacore, allowing conventional (non-multi) measurement sets to read from multiple threads.
