### PR TITLE
pyimages.cc: missing std::

### DIFF
--- a/src/pyimages.cc
+++ b/src/pyimages.cc
@@ -45,7 +45,7 @@ namespace casacore { namespace python {
 	    // 2 arg: concat from image names
       .def (init<Vector<String>, Int>())
             // 3 arg: open image or image expression
-      .def (init<String, String, vector<ImageProxy> >())
+      .def (init<String, String, std::vector<ImageProxy> >())
 	    // 4 arg: concat from images objects
       .def (init<std::vector<ImageProxy>, Int, Int, Int>())
             // 8 arg: create image from array


### PR DESCRIPTION
missing std:: causes GCC 10.2.0 to bail out.