### PR TITLE
Remove dependency on external argparse package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -260,7 +260,7 @@ class my_build_ext(build_ext_module.build_ext):
 setup(name='python-casacore',
       version=__version__,
       description='A wrapper around CASACORE, the radio astronomy library',
-      install_requires=['numpy', 'argparse', 'future', 'six'],
+      install_requires=['numpy', 'future', 'six'],
       author='Gijs Molenaar',
       author_email='gijs@pythonic.nl',
       url='https://github.com/casacore/python-casacore',


### PR DESCRIPTION
There are two problems with having an install_requires dependency on the
external argparse package: first, the argparse module has been included
in the Python standard library since 2.7 and 3.2, and therefore there's
no need to install it externally; and secondly, the code in
python-casacore doesn't use this dependency. In fact the only place
where argparse is used is in setup.py itself, which is a testimony that
the module shipped with the standard library is enough.

Probably the `future` package is also not needed (it's used only to import `print_function` in one of the tests, but `print` can be used as a function already in 2.7), I can push a commit for that as well if required.