### PR TITLE
Remove dependency on external future package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -260,7 +260,7 @@ class my_build_ext(build_ext_module.build_ext):
 setup(name='python-casacore',
       version=__version__,
       description='A wrapper around CASACORE, the radio astronomy library',
-      install_requires=['numpy', 'future', 'six'],
+      install_requires=['numpy', 'six'],
       author='Gijs Molenaar',
       author_email='gijs@pythonic.nl',
       url='https://github.com/casacore/python-casacore',

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
 from unittest import TestCase
 
 import numpy as np


### PR DESCRIPTION
Like in 2f9ed55, this commit removes the dependency on the external
future package, which isn't needed by python-casacore in its current
state and intended target python versions.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>