### PR TITLE
Test cibuildwheel for macOS wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,48 @@
+name: Build wheels
+
+on:
+  # Only a manual trigger for now
+  workflow_dispatch:
+
+env:
+  CIBW_BEFORE_ALL_MACOS: >
+    brew tap casacore/tap &&
+    brew install casacore --with-python
+  # Support native arm64 and universal2 = Intel + ARM for Apple Silicon
+  CIBW_ARCHS_MACOS: "x86_64 arm64 universal2"
+  # XXX (but don't test it yet - we first need some M1 runners)
+  CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
+
+jobs:
+  make_sdist:
+    name: Build SDist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build SDist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.6.0
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: wheelhouse/*.whl


### PR DESCRIPTION
I'm trying out a basic [cibuildwheel](https://cibuildwheel.readthedocs.io/en/stable/) workflow just for macOS wheels for now.

The main aim is to get those sweet arm64 wheels for Apple Silicon (M1) processors. 😁 

On success this could be extended to manylinux wheels too...
