### PR TITLE
Prepare for 3.5.2

### DIFF
--- a/.github/workflows/extract-wheels.sh
+++ b/.github/workflows/extract-wheels.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+for ver in 36 37 38 39 310; do
+  dockerid=$(docker create python-casacore-py${ver})
+  docker cp ${dockerid}:/output/ output-${ver}
+  docker rm ${dockerid}
+done

--- a/.github/workflows/make_images.sh
+++ b/.github/workflows/make_images.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -ve
+
+HERE=`dirname "$0"`
+cd $HERE/..
+
+for i in 36 37 38 39 310; do
+    docker build -f docker/py${i}_wheel.docker . -t quay.io/casacore/casacore:master_wheel${i}
+done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.5.2
+
+The binary wheels have now been built with `-DPORTABLE=True`. This should fix issues with Dysco crashing on some platforms (due to missing AVX instructions). Otherwise nothing has changed.
+
+
 # 3.5.1
 
 The binary wheel for python 3.10 is now based on numpy 1.22.4. Otherwise nothing has changed.

--- a/casacore/__init__.py
+++ b/casacore/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "3.5.1"
+__version__ = "3.5.2"
 __mincasacoreversion__ = "3.1.1"


### PR DESCRIPTION
The only fix is that the binary wheels have now been build with `-DPORTABLE=TRUE` so that Dysco works on all platforms.