### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/extract-wheels.sh
+++ b/.github/workflows/extract-wheels.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-for ver in 36 37 38 39 310; do
+for ver in 37 38 39 310 311; do
   dockerid=$(docker create python-casacore-py${ver})
   docker cp ${dockerid}:/output/ output-${ver}
   docker rm ${dockerid}

--- a/.github/workflows/make_images.sh
+++ b/.github/workflows/make_images.sh
@@ -3,6 +3,6 @@
 HERE=`dirname "$0"`
 cd $HERE/..
 
-for i in 36 37 38 39 310; do
+for i in 37 38 39 310 311; do
     docker build -f docker/py${i}_wheel.docker . -t quay.io/casacore/casacore:master_wheel${i}
 done

--- a/.github/workflows/py311_binary_wheel.docker
+++ b/.github/workflows/py311_binary_wheel.docker
@@ -1,4 +1,4 @@
-FROM quay.io/casacore/casacore:master_wheel36
+FROM quay.io/casacore/casacore:master_wheel311
 
 ADD . /python-casacore
 WORKDIR /python-casacore


### PR DESCRIPTION
Added support for building docker images for Python 3.11. Dropped support for Python 3.6, which is EOL.