### PR TITLE
Use raw string for RE pattern

### DIFF
--- a/casacore/measures/__init__.py
+++ b/casacore/measures/__init__.py
@@ -624,7 +624,7 @@ class measures(_measures):
         if not is_measure(v):
             raise TypeError('Incorrect input type for getvalue()')
         import re
-        rx = re.compile("m\d+")
+        rx = re.compile(r"m\d+")
         out = []
         keys = list(v.keys())
         keys.sort()


### PR DESCRIPTION
Otherwise the `\d` escape sequence doesn't make sense. This actually emits a warning in python 3.11.