### PR TITLE
Explicitly add Homebrew libs to support Apple M1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 Setup script for the CASACORE python wrapper.
 """
 import os
+import subprocess
 import sys
 import warnings
 from setuptools import setup, Extension, find_packages
@@ -52,7 +53,17 @@ def find_library_file(libname):
 
     if 'LD_LIBRARY_PATH' in os.environ:
         lib_dirs += os.environ['LD_LIBRARY_PATH'].split(':')
-
+    # Look for Homebrewed libraries
+    try:
+        homebrew_prefix = subprocess.run(
+            ['brew', '--prefix'],
+            capture_output=True,
+            check=True,
+            text=True
+        ).stdout.strip()
+        lib_dirs.append(join(homebrew_prefix, 'lib'))
+    except subprocess.CalledProcessError:
+        pass
     # Append default search path (not a complete list)
     lib_dirs += [join(sys.prefix, 'lib'),
                  '/usr/local/lib',


### PR DESCRIPTION
In the grand old days, Homebrew installed to `/usr/local` and all was well. Now, however, while Intel Homebrew still does this, Apple Silicon / M1 / M2 Homebrew has gone and picked a new prefix: `/opt/homebrew`. A good explanation of the rationale is at https://earthly.dev/blog/homebrew-on-m1/. Basically, Homebrew had to admit that Fink and MacPorts were right. 😛 

The solution is to call `brew --prefix` and add those libraries explicitly to the search list. Keep going if brew is not installed.

This addresses #252.