### PR TITLE
Fix brew not found error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ def find_library_file(libname):
             text=True
         ).stdout.strip()
         lib_dirs.append(join(homebrew_prefix, 'lib'))
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         pass
     # Append default search path (not a complete list)
     lib_dirs += [join(sys.prefix, 'lib'),


### PR DESCRIPTION
On linux systems, calling `brew` does not raise a CalledProcessError but a FileNotFoundError.