### PR TITLE
Add casacore data files to package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,5 @@
-include README.rst *.py LICENSE
-recursive-include src *.cc *.h
+include *.rst *.md
+graft casacore/data
+graft doc
+graft src
+graft tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include *.rst *.md
+include casacore/.aipsrc
 graft casacore/data
 graft doc
 graft src

--- a/casacore/.aipsrc
+++ b/casacore/.aipsrc
@@ -1,0 +1,1 @@
+measures.directory: ${CASACORE_DATA}

--- a/casacore/.aipsrc
+++ b/casacore/.aipsrc
@@ -1,1 +1,1 @@
-measures.directory: ${CASACORE_DATA}
+measures.directory: ${CASACORE_DATADIR}

--- a/casacore/__init__.py
+++ b/casacore/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.6.0a1"
+__version__ = "3.5.3"
 __mincasacoreversion__ = "3.1.1"
 
 import os

--- a/casacore/__init__.py
+++ b/casacore/__init__.py
@@ -5,9 +5,9 @@ import os
 
 # If environment variable `AIPSPATH` is not set, then set it to the directory
 # containing the `.aipsrc` file that is distributed with this package.
-# This `.aipsrc` file uses the environment `CASACORE_DATA`, which should point
-# to the directory containing the casacore data files.
+# This `.aipsrc` file uses the environment `CASACORE_DATADIR`, which should
+# point to the directory containing the casacore data files.
 if "AIPSPATH" not in os.environ:
     root = os.path.dirname(__file__)
     os.environ["AIPSPATH"] = root
-    os.environ["CASACORE_DATA"] = os.path.join(root, "data")
+    os.environ["CASACORE_DATADIR"] = os.path.join(root, "data")

--- a/casacore/__init__.py
+++ b/casacore/__init__.py
@@ -1,2 +1,13 @@
-__version__ = "3.5.2"
+__version__ = "3.6.0a1"
 __mincasacoreversion__ = "3.1.1"
+
+import os
+
+# If environment variable `AIPSPATH` is not set, then set it to the directory
+# containing the `.aipsrc` file that is distributed with this package.
+# This `.aipsrc` file uses the environment `CASACORE_DATA`, which should point
+# to the directory containing the casacore data files.
+if "AIPSPATH" not in os.environ:
+    root = os.path.dirname(__file__)
+    os.environ["AIPSPATH"] = root
+    os.environ["CASACORE_DATA"] = os.path.join(root, "data")

--- a/setup.py
+++ b/setup.py
@@ -254,11 +254,15 @@ os.environ['OPT'] = " ".join(
     flag for flag in opt.split() if flag != '-Wstrict-prototypes'
 )
 
+
 def create_symlink(src_dir, dest_dir):
     """
-    Create a symbolic link from `src_dir` to `dest_dir`, unless `dest_dir` already exists.
+    Create a symbolic link from `src_dir` to `dest_dir`, unless `dest_dir`
+    already exists.
     Return `dest_dir` upon success, or an empty string upon failure.
     """
+    if os.path.islink(dest_dir):
+        os.remove(dest_dir)
     try:
         os.symlink(src_dir, dest_dir)
     except FileExistsError:
@@ -271,7 +275,7 @@ def create_symlink(src_dir, dest_dir):
 class my_build_ext(build_ext_module.build_ext):
     def run(self):
         casacoreversion = find_casacore_version()
-        if casacoreversion is not None and  LooseVersion(casacoreversion) < LooseVersion(__mincasacoreversion__):
+        if casacoreversion is not None and LooseVersion(casacoreversion) < LooseVersion(__mincasacoreversion__):
             errorstr = "Your casacore version is too old. Minimum is " + __mincasacoreversion__ + \
                        ", you have " + casacoreversion
             if casacoreversion == "2.5.0":
@@ -290,10 +294,10 @@ setup(name='python-casacore',
       keywords=['pyrap', 'casacore', 'utilities', 'astronomy'],
       long_description=read('README.rst'),
       long_description_content_type='text/x-rst',
-      packages=find_packages() + find_namespace_packages(include=["data.*"]),
+      packages=find_packages() + find_namespace_packages(include=["casacore.data.*"]),
       include_package_data=True,
       package_data={
-          "data": [create_symlink(os.getenv("CASACORE_DATA"), "data")]
+          "casacore.data": [create_symlink(os.getenv("CASACORE_DATA"), "casacore/data")]
       },
       ext_modules=get_extensions(),
       cmdclass={'build_ext': my_build_ext},

--- a/setup.py
+++ b/setup.py
@@ -296,6 +296,13 @@ setup(name='python-casacore',
       long_description_content_type='text/x-rst',
       packages=find_packages() + find_namespace_packages(include=["casacore.data.*"]),
       include_package_data=True,
+      # We need to bring the casacore data files in scope of the python package.
+      # There is no need to copy the files, creating a symlink suffices. Environment
+      # variable `CASACORE_DATA` must point to the directory containing the data files.
+      # If `CASACORE_DATA` is not set, or points to a non-existing directory, no data
+      # will be added to the python package. If `casacore/data` already exists and is
+      # not a symlink, then no attempt is made to create a symlink; the contents of
+      # `casacore/data` will be used instead.
       package_data={
           "casacore.data": [create_symlink(os.getenv("CASACORE_DATA"), "casacore/data")]
       },


### PR DESCRIPTION
This PR ensures that the `casacore` data files (ephemerides and geodetic) are added to the generated source and binary distribution, and that they can be found at runtime.

To test the latter, you can use the following command, which should succeed:
```
python -c "from casacore.tables import taql; taql('calc meas.azel(\"Jupiter\",2016-06-28 19:54,\"DWL\") deg')"
```