### PR TITLE
Require Boost python3 component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(
 # Find Casacore and its dependencies
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 find_package(Casacore REQUIRED)
-find_package(Boost REQUIRED COMPONENTS python)
+find_package(Boost REQUIRED COMPONENTS python3)
 
 # If environment variable CASACORE_DATA is set, assume it points to a directory
 # containing the cascacore data files, and install its contents.


### PR DESCRIPTION
On some systems, the wrong Boost.Python version is searched if the component name is not explicitly given as `python3`. This is now fixed.