### PR TITLE
Fix find_package for Boost.Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(
 # Find Casacore and its dependencies
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 find_package(Casacore REQUIRED)
-find_package(Boost REQUIRED COMPONENTS python3)
+find_package(Boost REQUIRED COMPONENTS python${Python_VERSION_MAJOR}${Python_VERSION_MINOR})
 
 # If environment variable CASACORE_DATA is set, assume it points to a directory
 # containing the cascacore data files, and install its contents.


### PR DESCRIPTION
On some platforms you need to explicitly specify both major and minor python version number to `FindBoost.cmake`.