### PR TITLE
Fix GitHub action that uploads to PyPI

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -42,7 +42,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16
+        uses: pypa/cibuildwheel@v2.23
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -62,7 +62,7 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     # Upload to PyPI on every tag starting with 'v'
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+#    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     # Alternatively, to publish when a GitHub Release is created, use the following rule:
     # if: github.event_name == 'release' && github.event.action == 'published'
     steps:
@@ -73,6 +73,6 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           # For testing, use TestPyPI
-          # repository-url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
           skip-existing: true
           verbose: true

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -62,7 +62,7 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     # Upload to PyPI on every tag starting with 'v'
-#    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     # Alternatively, to publish when a GitHub Release is created, use the following rule:
     # if: github.event_name == 'release' && github.event.action == 'published'
     steps:
@@ -73,6 +73,6 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           # For testing, use TestPyPI
-          repository-url: https://test.pypi.org/legacy/
+          # repository-url: https://test.pypi.org/legacy/
           skip-existing: true
           verbose: true

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -25,6 +25,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: tarball
           path: dist/*.tar.gz
 
   build_wheels:
@@ -46,10 +47,8 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
+          name: wheels-${{ matrix.os }}
           path: wheelhouse/*.whl
-          # Temporary allow overwrite until we use setuptools_scm to
-          # generate unique version numbers on every push
-          overwrite: true
 
   upload_pypi:
     name: Upload release to PyPI
@@ -61,7 +60,7 @@ jobs:
       # For testing, use TestPyPI
       # url: https://test.pypi.org/p/python-casacore
     permissions:
-      id-token: write
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     # Upload to PyPI on every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     # Alternatively, to publish when a GitHub Release is created, use the following rule:
@@ -69,12 +68,9 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          # unpacks default artifact into dist/
-          # if `name: artifact` is omitted, the action will create extra parent dir
-          name: artifact
-          path: dist
-
-      - uses: pypa/gh-action-pypi-publish@v1.8.11
+          path: dist  # put artifacts where next action expects them to be
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           # For testing, use TestPyPI
           # repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,6 +3,7 @@ name: Linux
 on:
   push:
     branches: [ master ]
+    tags: [ "*" ]
   pull_request:
     branches: [ master ]
 
@@ -11,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         dist:
           - py3_casacore_master
     steps:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   osx:
-    runs-on: macos-11
+    runs-on: macos-13
     continue-on-error: true
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ Homepage = "https://github.com/casacore/python-casacore"
 #########################
 
 [tool.cibuildwheel]
-build = "cp312-*_x86_64"
+build = "cp3{8,9,10,11,12,13}-*_x86_64"
 build-verbosity = 1
 environment = """ \
     CXXFLAGS="-I/usr/include/cfitsio" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ Homepage = "https://github.com/casacore/python-casacore"
 #########################
 
 [tool.cibuildwheel]
-build = "cp313-*_x86_64"
+build = "cp312-*_x86_64"
 build-verbosity = 1
 environment = """ \
     CXXFLAGS="-I/usr/include/cfitsio" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ Homepage = "https://github.com/casacore/python-casacore"
 #########################
 
 [tool.cibuildwheel]
-build = "cp3{8,9,10,11,12,13}-*_x86_64"
+build = "cp313-*_x86_64"
 build-verbosity = 1
 environment = """ \
     CXXFLAGS="-I/usr/include/cfitsio" \


### PR DESCRIPTION
The current GitHub action that builds and publishes a release, fails to upload the source tar ball. The MR fixes the broken action. The probable cause of this was probably a half-baked upgrade to `v4` of the `upload` and `download` actions.