### PR TITLE
Fix bug in build_release workflow

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -56,13 +56,13 @@ jobs:
     needs: [build_sdist, build_wheels]
     environment:
       name: pypi
-      url: https://pypi.org/p/python-casacore
+      # url: https://pypi.org/p/python-casacore
       # For testing, use TestPyPI
-      # url: https://test.pypi.org/p/python-casacore
+      url: https://test.pypi.org/p/python-casacore
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     # Upload to PyPI on every tag starting with 'v'
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+#    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     # Alternatively, to publish when a GitHub Release is created, use the following rule:
     # if: github.event_name == 'release' && github.event.action == 'published'
     steps:
@@ -73,6 +73,6 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           # For testing, use TestPyPI
-          # repository-url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
           skip-existing: true
           verbose: true

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -56,9 +56,9 @@ jobs:
     needs: [build_sdist, build_wheels]
     environment:
       name: pypi
-      url: https://pypi.org/p/python-casacore
+      # url: https://pypi.org/p/python-casacore
       # For testing, use TestPyPI
-      # url: https://test.pypi.org/p/python-casacore
+      url: https://test.pypi.org/p/python-casacore
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     # Upload to PyPI on every tag starting with 'v'

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -56,13 +56,13 @@ jobs:
     needs: [build_sdist, build_wheels]
     environment:
       name: pypi
-      # url: https://pypi.org/p/python-casacore
+      url: https://pypi.org/p/python-casacore
       # For testing, use TestPyPI
-      url: https://test.pypi.org/p/python-casacore
+      # url: https://test.pypi.org/p/python-casacore
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     # Upload to PyPI on every tag starting with 'v'
-#    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     # Alternatively, to publish when a GitHub Release is created, use the following rule:
     # if: github.event_name == 'release' && github.event.action == 'published'
     steps:
@@ -73,6 +73,6 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           # For testing, use TestPyPI
-          repository-url: https://test.pypi.org/legacy/
+          # repository-url: https://test.pypi.org/legacy/
           skip-existing: true
           verbose: true

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         dist:
           - py3_casacore_master
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,6 +3,7 @@ name: Linux
 on:
   push:
     branches: [ master ]
+    tags: [ "*" ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   osx:
-    runs-on: macos-latest
+    runs-on: macos-13
     continue-on-error: true
 
     steps:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   osx:
-    runs-on: macos-11
+    runs-on: macos-latest
     continue-on-error: true
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ Homepage = "https://github.com/casacore/python-casacore"
 #########################
 
 [tool.cibuildwheel]
-build = "cp3{8,9,10,11,12,13}-*_x86_64"
+build = "cp312-*_x86_64"
 build-verbosity = 1
 environment = """ \
     CXXFLAGS="-I/usr/include/cfitsio" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ Homepage = "https://github.com/casacore/python-casacore"
 #########################
 
 [tool.cibuildwheel]
-build = "cp312-*_x86_64"
+build = "cp3{8,9,10,11,12,13}-*_x86_64"
 build-verbosity = 1
 environment = """ \
     CXXFLAGS="-I/usr/include/cfitsio" \


### PR DESCRIPTION
Fixed a bug in the `build_release.yml` workflow that caused only binary wheels to be uploaded to PyPI.
Also fixed a few other minor issues with the workflows `linux.yml` and `osx.yml`.