### PR TITLE
Prepare releaes v3.8.1

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -21,6 +21,7 @@ jobs:
 
       - name: install homebrew packages
         run: |
+          brew trust casacore/tap
           brew tap casacore/tap 
           brew install casacore --with-python
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This version as a binary wheel ships with underlying casacore v3.8.1.
 
 Support for Python 3.8 and 3.9 was dropped; support for Python 3.14 was added.
+This version requires a C++-20 compatible compiler.
 
 # 3.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.8.1
+
+This version as a binary wheel ships with underlying casacore v3.8.1.
+
+Support for Python 3.8 and 3.9 was dropped; support for Python 3.14 was added.
+
 # 3.7.1
 
 This version as a binary wheel ships with underlying casacore v3.7.1.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15...3.26)
 project(python-casacore)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 find_package(


### PR DESCRIPTION
Some more changes for release v3.8.1

* Updated Changelog
* Since we're now using a `casacore` base image that is compiled with C++-20, we also need to do this here, just to be safe.
* Explicitly trust `casacore/tap` when running `brew` for MacOS CI build.